### PR TITLE
fix(ci): Explicitly set VCPKG_ROOT in release workflow

### DIFF
--- a/.github/workflows/CI-09_create-releases.yml
+++ b/.github/workflows/CI-09_create-releases.yml
@@ -52,9 +52,7 @@ jobs:
         run: |
           git clone https://github.com/microsoft/vcpkg.git
           .\vcpkg\bootstrap-vcpkg.bat
-          "VCPKG_ROOT=${{ github.workspace }}\vcpkg" >> $env:GITHUB_ENV
         shell: pwsh
-
       - name: Install ffmpeg via vcpkg
         run: |
           .\vcpkg\vcpkg.exe install ffmpeg:x64-windows
@@ -63,6 +61,7 @@ jobs:
 
       - name: Build Release (Windows)
         env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
           PATH: ${{ github.workspace }}\vcpkg\installed\x64-windows\bin;${{ env.PATH }}
         run: cargo build --release -p mapmap
         shell: pwsh
@@ -119,7 +118,6 @@ jobs:
         run: |
           git clone https://github.com/microsoft/vcpkg.git
           .\vcpkg\bootstrap-vcpkg.bat
-          "VCPKG_ROOT=${{ github.workspace }}\vcpkg" >> $env:GITHUB_ENV
         shell: pwsh
 
       - name: Install ffmpeg via vcpkg
@@ -130,6 +128,7 @@ jobs:
 
       - name: Build Release (Windows)
         env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
           PATH: ${{ github.workspace }}\vcpkg\installed\x64-windows\bin;${{ env.PATH }}
         run: cargo build --release -p mapmap
         shell: pwsh


### PR DESCRIPTION
Sets VCPKG_ROOT in the build step env to ensure ffmpeg-sys-next finds the vcpkg installation.