### PR TITLE
docs: fix broken links and resolve build errors

### DIFF
--- a/crates/mapmap-core/src/monitor.rs
+++ b/crates/mapmap-core/src/monitor.rs
@@ -122,7 +122,7 @@ impl MonitorTopology {
 /// called during application initialization
 #[allow(unexpected_cfgs)]
 #[cfg(feature = "winit")]
-pub fn detect_monitors_winit<T>(event_loop: &winit::event_loop::EventLoop<T>) -> MonitorTopology {
+pub fn detect_monitors_winit(event_loop: &winit::event_loop::ActiveEventLoop) -> MonitorTopology {
     use winit::monitor::MonitorHandle;
 
     let mut monitors = Vec::new();


### PR DESCRIPTION
This submission addresses multiple issues:
1.  **Documentation Links:** Fixed broken links in `CONTRIBUTING.md`, `GETTING-STARTED`, and `ROADMAP` documentation to ensure navigation works correctly. Removed a broken image reference in `MIDI_CONTROL.md`.
2.  **Build Fix:** Resolved a compilation error in `crates/mapmap-core/src/monitor.rs`. The `detect_monitors_winit` function signature was outdated for `winit` 0.30 (used `EventLoop` instead of `ActiveEventLoop`). This was causing CI build failures.
3.  **CI Compliance:** Merged `origin/main` into the branch to satisfy the "PR branch up-to-date" check in the CI pipeline.

---
*PR created automatically by Jules for task [16501634931899010849](https://jules.google.com/task/16501634931899010849) started by @MrLongNight*