### PR TITLE
UX: Add Safe Reset and Live Header to Effect Node

### DIFF
--- a/crates/mapmap-ui/src/module_canvas.rs
+++ b/crates/mapmap-ui/src/module_canvas.rs
@@ -1427,17 +1427,43 @@ impl ModuleCanvas {
                                         ui.label("Modulator:");
                                         match mod_type {
                                             ModulizerType::Effect { effect_type: effect, params } => {
-                                                // High contrast header
-                                                ui.add_space(5.0);
-                                                ui.vertical_centered(|ui| {
-                                                    ui.heading(egui::RichText::new(effect.name()).color(Color32::WHITE).strong());
-                                                });
+                                                // === LIVE HEADER ===
                                                 ui.add_space(5.0);
 
-                                                // Reset Defaults Button
-                                                if ui.button("↺ Reset Defaults").clicked() {
-                                                     Self::set_default_effect_params(*effect, params);
-                                                }
+                                                // 1. Big Title
+                                                ui.vertical_centered(|ui| {
+                                                    ui.label(
+                                                        egui::RichText::new(effect.name())
+                                                            .size(22.0)
+                                                            .color(Color32::from_rgb(100, 200, 255))
+                                                            .strong(),
+                                                    );
+                                                });
+                                                ui.add_space(10.0);
+
+                                                // 2. Safe Reset Button (Prominent)
+                                                ui.vertical_centered(|ui| {
+                                                    if ui
+                                                        .add(
+                                                            egui::Button::new(
+                                                                egui::RichText::new("⟲ Safe Reset")
+                                                                    .size(14.0),
+                                                            )
+                                                            .min_size(Vec2::new(140.0, 32.0)),
+                                                        )
+                                                        .on_hover_text(
+                                                            "Reset all parameters to safe defaults",
+                                                        )
+                                                        .clicked()
+                                                    {
+                                                        Self::set_default_effect_params(
+                                                            *effect, params,
+                                                        );
+                                                    }
+                                                });
+
+                                                ui.add_space(10.0);
+                                                ui.separator();
 
                                                 let mut changed_type = None;
 


### PR DESCRIPTION
This PR enhances the UX of the Effect Node inspector in the node editor. It introduces a "Live Header" design pattern, similar to the Media Player node, featuring a large, colored title and a prominent "Safe Reset" button. This change makes it easier to identify the active effect and quickly reset its parameters to safe defaults during live operation. The underlying logic for resetting parameters remains unchanged.

---
*PR created automatically by Jules for task [14954546218874106892](https://jules.google.com/task/14954546218874106892) started by @MrLongNight*