### PR TITLE
⚡ Bolt: Eliminate deep clone of modules in sidebar render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-06-21 - Immediate Mode Geometry Checks
 **Learning:** In immediate mode UIs (`egui`), complex geometry checks (like iterative Bezier hit testing) running per-frame for every object (N connections) creates a linear CPU bottleneck. A simple AABB broad-phase check dramatically reduces the work for the vast majority of non-interacted objects.
 **Action:** Always implement a cheap broad-phase check (AABB, bounding circle) before performing expensive detailed hit testing in render loops.
+
+## 2026-10-24 - Deep Cloning in UI Loops
+**Learning:** `module_sidebar.rs` was performing `modules.into_iter().cloned().collect()` inside the `show()` method (called every frame). This deep-cloned the entire module graph (nodes, connections, strings) 60 times a second, creating massive unnecessary allocation traffic.
+**Action:** When iterating collections for UI display, always prefer iterating references (`&T`) directly. If a closure requires ownership of a field (like `id: u64`), capture just that field, not the whole struct.

--- a/crates/mapmap-ui/src/module_sidebar.rs
+++ b/crates/mapmap-ui/src/module_sidebar.rs
@@ -28,9 +28,9 @@ impl ModuleSidebar {
 
             // List of modules
             let modules = manager.list_modules();
-            let module_list: Vec<_> = modules.into_iter().cloned().collect();
-            for module in module_list {
-                let response = self.module_list_item(ui, &module);
+            // Optimization: Iterate over references to avoid deep cloning MapFlowModule every frame
+            for module in modules {
+                let response = self.module_list_item(ui, module);
                 response.context_menu(|ui| {
                     if ui.button(locale.t("menu-rename")).clicked() {
                         // TODO: Implement renaming


### PR DESCRIPTION
⚡ Bolt: Eliminate deep clone of modules in sidebar render loop

💡 What:
Removed the `let module_list: Vec<_> = modules.into_iter().cloned().collect();` line in `crates/mapmap-ui/src/module_sidebar.rs` and updated the loop to iterate over the `Vec<&MapFlowModule>` references returned by `manager.list_modules()` directly.

🎯 Why:
The `MapFlowModule` struct contains vectors of parts and connections, strings, and hashmaps. Deep cloning this entire structure 60 times a second (every UI frame) generates significant garbage and CPU overhead, especially as the project size grows. This allocation was unnecessary as the UI only reads data or captures IDs for actions.

📊 Impact:
- Eliminates one O(N) deep clone per frame where N is the number of modules.
- Reduces memory bandwidth usage and allocator pressure during UI rendering.

🔬 Measurement:
Verified with `cargo test -p mapmap-ui` to ensure no regressions in sidebar logic. The change is purely internal to the iteration logic and does not affect the visual output or behavior.

---
*PR created automatically by Jules for task [11790396368666959158](https://jules.google.com/task/11790396368666959158) started by @MrLongNight*