### PR TITLE
UX: Safe Node Deletion (Hold-to-Confirm)

### DIFF
--- a/.jules/mary-styleux.md
+++ b/.jules/mary-styleux.md
@@ -1,9 +1,8 @@
-# 📓 MARY STYLEUX JOURNAL
+# Mary StyleUX Journal
 
-## 🧠 PHILOSOPHY
-**Focus:** Interaction safety, accessibility, live-performance reliability.
-**Goal:** MapFlow must be predictable under stress.
-
-## 2024-05-23 – Initial Setup
-**Learning:** Initialized Mary StyleUX persona.
-**Action:** Starting work on safe interaction patterns for destructive actions (Hold-to-Confirm).
+## 2024-05-24 – Safe Destructive Actions
+**Learning:** Immediate "click-to-delete" buttons on nodes are dangerous in live performance contexts. Users may accidentally delete a critical node while trying to select or move it.
+**Action:** Implemented a "Hold-to-Confirm" pattern (0.6s hold) for node deletion.
+- **Visuals:** Added a circular progress indicator filling the delete button.
+- **Interaction:** Requires holding mouse button OR focusing and holding Space/Enter.
+- **Accessibility:** Ensure custom interactive rects support focus and keyboard events if they replace standard buttons. Replaced duplicated layout logic with a helper method to ensure hit-testing and rendering stay in sync.


### PR DESCRIPTION
This PR enhances the safety of the node deletion workflow in the MapFlow UI. 

Previously, clicking the small "x" button on a node immediately deleted it, which posed a high risk of accidental deletion during live performance or complex editing.

**Changes:**
1.  **Hold-to-Confirm:** Deletion now requires holding the button for 0.6 seconds.
2.  **Visual Feedback:** A red circular progress indicator fills the button during the hold action.
3.  **Accessibility:** The interaction supports keyboard users. If the button has focus, holding Space or Enter triggers the delete action.
4.  **Refactoring:** Extracted `get_delete_button_rect` to eliminate code duplication and ensure consistent hit-testing.

**Testing:**
- Verified via `cargo check` and `cargo test -p mapmap-ui`.
- Confirmed accessibility logic matches the pattern used in `hold_to_action_button` widget.


---
*PR created automatically by Jules for task [13927416052377758640](https://jules.google.com/task/13927416052377758640) started by @MrLongNight*