### PR TITLE
Guardian: Add unit tests and Debug for NDI stubs

### DIFF
--- a/crates/mapmap-io/src/ndi/mod.rs
+++ b/crates/mapmap-io/src/ndi/mod.rs
@@ -355,6 +355,7 @@ impl NdiSender {
 // Stub implementations when NDI feature is disabled
 /// NDI receiver stub (NDI feature disabled)
 #[cfg(not(feature = "ndi"))]
+#[derive(Debug)]
 pub struct NdiReceiver;
 
 #[cfg(not(feature = "ndi"))]
@@ -367,6 +368,7 @@ impl NdiReceiver {
 
 /// NDI sender stub (NDI feature disabled)
 #[cfg(not(feature = "ndi"))]
+#[derive(Debug)]
 pub struct NdiSender;
 
 #[cfg(not(feature = "ndi"))]
@@ -388,4 +390,35 @@ pub struct NdiSource {
     pub name: String,
     /// Source URL
     pub url_address: Option<String>,
+}
+
+#[cfg(test)]
+#[cfg(not(feature = "ndi"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ndi_receiver_stub() {
+        let result = NdiReceiver::new();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "NDI feature not enabled");
+    }
+
+    #[test]
+    fn test_ndi_sender_stub() {
+        let format = crate::format::VideoFormat::hd_1080p30_rgba();
+        let result = NdiSender::new("test", format);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "NDI feature not enabled");
+    }
+
+    #[test]
+    fn test_ndi_source_stub() {
+        let source = NdiSource {
+            name: "test".to_string(),
+            url_address: None,
+        };
+        assert_eq!(source.name, "test");
+        assert!(source.url_address.is_none());
+    }
 }


### PR DESCRIPTION
Re-implemented Guardian work: Added `#[derive(Debug)]` to NDI stub structs in `mapmap-io` and added unit tests to verify graceful degradation when the NDI feature is disabled. Tests ensure that using NDI components without the feature enabled results in a predictable error rather than a crash or undefined behavior.

---
*PR created automatically by Jules for task [10917511701853216056](https://jules.google.com/task/10917511701853216056) started by @MrLongNight*