### PR TITLE
⚡ Bolt: Remove hot-path allocation in Inspector

### DIFF
--- a/crates/mapmap-core/src/module.rs
+++ b/crates/mapmap-core/src/module.rs
@@ -2234,6 +2234,17 @@ impl ModuleManager {
         self.modules.get_mut(&id)
     }
 
+    /// Get module by ID (mutable) AND shared media state (immutable)
+    /// This allows accessing both simultaneously without borrow checker issues
+    pub fn get_module_mut_and_shared_media(
+        &mut self,
+        id: ModuleId,
+    ) -> Option<(&mut MapFlowModule, &SharedMediaState)> {
+        let module = self.modules.get_mut(&id)?;
+        let shared_media = &self.shared_media;
+        Some((module, shared_media))
+    }
+
     /// Get a module by ID (immutable)
     pub fn get_module(&self, id: ModuleId) -> Option<&MapFlowModule> {
         self.modules.get(&id)

--- a/crates/mapmap-ui/src/editors/module_canvas.rs
+++ b/crates/mapmap-ui/src/editors/module_canvas.rs
@@ -662,13 +662,13 @@ impl ModuleCanvas {
         }
     }
 
-    pub fn render_inspector_for_part(
+    pub fn render_inspector_for_part<'a>(
         &mut self,
         ui: &mut Ui,
         part: &mut mapmap_core::module::ModulePart,
         actions: &mut Vec<UIAction>,
         module_id: mapmap_core::module::ModuleId,
-        shared_media_ids: &[String],
+        shared_media_ids: impl Iterator<Item = &'a String> + Clone,
     ) {
         // Sync mesh editor state if needed
         self.sync_mesh_editor_to_current_selection(part);
@@ -1125,7 +1125,7 @@ impl ModuleCanvas {
                                                     egui::ComboBox::from_id_salt("shared_media_video")
                                                         .selected_text("Select Existing")
                                                         .show_ui(ui, |ui| {
-                                                            for id in shared_media_ids {
+                                                            for id in shared_media_ids.clone() {
                                                                 if ui.selectable_label(shared_id == id, id).clicked() {
                                                                     *shared_id = id.clone();
                                                                 }
@@ -1152,7 +1152,7 @@ impl ModuleCanvas {
                                                     egui::ComboBox::from_id_salt("shared_media_image")
                                                         .selected_text("Select Existing")
                                                         .show_ui(ui, |ui| {
-                                                            for id in shared_media_ids {
+                                                            for id in shared_media_ids.clone() {
                                                                 if ui.selectable_label(shared_id == id, id).clicked() {
                                                                     *shared_id = id.clone();
                                                                 }

--- a/crates/mapmap-ui/src/lib.rs
+++ b/crates/mapmap-ui/src/lib.rs
@@ -557,17 +557,16 @@ impl AppUI {
         // 1. Module Selection
         if self.show_module_canvas {
             if let Some(module_id) = self.module_canvas.active_module_id {
-                // Collect shared media IDs before borrowing module mutably from manager
-                let shared_media_ids: Vec<String> =
-                    module_manager.shared_media.items.keys().cloned().collect();
-
-                if let Some(module) = module_manager.get_module_mut(module_id) {
+                // Use split borrow to avoid allocation
+                if let Some((module, shared_media)) =
+                    module_manager.get_module_mut_and_shared_media(module_id)
+                {
                     if let Some(part_id) = self.module_canvas.get_selected_part_id() {
                         context = crate::InspectorContext::Module {
                             canvas: &mut self.module_canvas,
                             module,
                             part_id,
-                            shared_media_ids,
+                            shared_media,
                         };
                     }
                 }

--- a/crates/mapmap-ui/src/panels/inspector_panel.rs
+++ b/crates/mapmap-ui/src/panels/inspector_panel.rs
@@ -47,7 +47,7 @@ pub enum InspectorContext<'a> {
         canvas: &'a mut crate::ModuleCanvas,
         module: &'a mut mapmap_core::module::MapFlowModule,
         part_id: mapmap_core::module::ModulePartId,
-        shared_media_ids: Vec<String>,
+        shared_media: &'a mapmap_core::module::SharedMediaState,
     },
 }
 
@@ -119,7 +119,7 @@ impl InspectorPanel {
                         canvas,
                         module,
                         part_id,
-                        shared_media_ids,
+                        shared_media,
                     } => {
                         if let Some(part) = module.parts.iter_mut().find(|p| p.id == part_id) {
                             canvas.render_inspector_for_part(
@@ -127,7 +127,7 @@ impl InspectorPanel {
                                 part,
                                 global_actions,
                                 module.id,
-                                &shared_media_ids,
+                                shared_media.items.keys(),
                             );
                         } else {
                             self.show_no_selection(ui, i18n);


### PR DESCRIPTION
This PR optimizes the `render_inspector` loop by removing a per-frame allocation of `Vec<String>` (and associated string cloning) which was used to populate the shared media dropdown. By implementing disjoint borrowing in `ModuleManager` and updating `ModuleCanvas` to accept an iterator, we now pass references directly, resulting in zero allocation for this operation.

---
*PR created automatically by Jules for task [13325894104465554798](https://jules.google.com/task/13325894104465554798) started by @MrLongNight*