### PR TITLE
fix: Resolve clippy warnings for Bevy 3D Text Node

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -17,62 +17,62 @@
 
 ## 2024-05-24 - [State Persistence]
 
-**Erkenntnis:** `AppState` serialization tests were only checking a subset of fields, risking silent data loss for new features. Deep checking of 
-default states revealed nested managers must also be verified. `dirty` flag exclusion must be explicitly tested to avoid false positive 
+**Erkenntnis:** `AppState` serialization tests were only checking a subset of fields, risking silent data loss for new features. Deep checking of
+default states revealed nested managers must also be verified. `dirty` flag exclusion must be explicitly tested to avoid false positive
 "unsaved changes" warnings.
-**Aktion:** Refactored `test_app_state_serialization_roundtrip` to use `assert_eq!` on the full struct (via `PartialEq`). Added specific test 
+**Aktion:** Refactored `test_app_state_serialization_roundtrip` to use `assert_eq!` on the full struct (via `PartialEq`). Added specific test
 `test_dirty_flag_excluded` to guarantee transient flags are not persisted.
 
 ## 2024-05-25 - [MIDI Parsing]
 
-**Erkenntnis:** `MidiMessage` parsing logic for PitchBend (14-bit reconstruction) and system messages (Start/Stop) was implemented but untested. 
+**Erkenntnis:** `MidiMessage` parsing logic for PitchBend (14-bit reconstruction) and system messages (Start/Stop) was implemented but untested.
 This created a risk for hardware controllers relying on high-resolution input or transport controls.
-**Aktion:** Implemented `test_midi_message_parsing_extended` covering full 14-bit Pitch Bend reconstruction and all system realtime messages 
+**Aktion:** Implemented `test_midi_message_parsing_extended` covering full 14-bit Pitch Bend reconstruction and all system realtime messages
 to ensure reliable hardware integration.
 
 ## 2024-05-26 - [Trigger System Integration]
 
-**Erkenntnis:** `TriggerSystem` integration logic was untested. While `TriggerConfig` logic was tested, the actual mapping of Audio FFT bands 
+**Erkenntnis:** `TriggerSystem` integration logic was untested. While `TriggerConfig` logic was tested, the actual mapping of Audio FFT bands
 to socket indices (0-8, 9-11) in the `update` loop was unverified, leaving a gap in ensuring audio reactivity works end-to-end.
-**Aktion:** Restored `tests/trigger_system_tests.rs` with mocks for `ModuleManager` and `AudioTriggerData`, ensuring every frequency band 
+**Aktion:** Restored `tests/trigger_system_tests.rs` with mocks for `ModuleManager` and `AudioTriggerData`, ensuring every frequency band
 and volume trigger fires correctly.
 
 ## 2024-10-24 - TriggerSystem Coverage
 
-**Insight:** `TriggerSystem` in `mapmap-core` was a critical logic component with zero unit tests. It relies heavily on `ModuleManager` 
+**Insight:** `TriggerSystem` in `mapmap-core` was a critical logic component with zero unit tests. It relies heavily on `ModuleManager`
 and `AudioTriggerData` integration.
-**Action:** Implemented integration tests using `ModuleManager` to simulate module configuration and `AudioTriggerData` to simulate input. 
+**Action:** Implemented integration tests using `ModuleManager` to simulate module configuration and `AudioTriggerData` to simulate input.
 This pattern effectively tests the interaction without needing full app state.
 
 ## 2024-10-25 - BPM Estimation Simulation
 
-**Insight:** Verified that simulating audio buffers (chunked sine waves) effectively tests complex DSP logic like BPM detection without 
+**Insight:** Verified that simulating audio buffers (chunked sine waves) effectively tests complex DSP logic like BPM detection without
 needing real audio files or hardware.
 **Action:** Use synthesized audio chunks for future audio analyzer tests to ensure deterministic behavior.
 
 ## 2024-10-26 - Part Socket Verification
 
-**Insight:** Iterating over all `PartType` variants in a test to verify socket generation catches "orphan" parts that might be added to 
+**Insight:** Iterating over all `PartType` variants in a test to verify socket generation catches "orphan" parts that might be added to
 the enum but lack input/output definitions, which leads to broken UI states.
 **Action:** Apply this "enum iteration" pattern to other factory-like methods to ensure complete coverage of new variants.
 
 ## 2024-10-26 - Audio Buffer Resizing
 
-**Insight:** Testing `update_config` in audio analyzers is critical because mismatched buffer sizes (e.g., between FFT and input buffers) 
+**Insight:** Testing `update_config` in audio analyzers is critical because mismatched buffer sizes (e.g., between FFT and input buffers)
 are a common source of runtime panics or silent failures when users change settings.
 **Action:** Always include a "reconfiguration" test case for stateful processing components like audio analyzers or render pipelines.
 
 ## 2024-10-27 - [Audio Pipeline Robustness]
 
-**Insight:** Testing threaded audio pipelines requires robust "polling atomics" (loops with `yield_now`) rather than fixed sleeps to avoid 
-flakiness and ensure valid data flow verification (e.g. `rms_volume > 0`). Explicit struct initialization in tests prevents Clippy 
+**Insight:** Testing threaded audio pipelines requires robust "polling atomics" (loops with `yield_now`) rather than fixed sleeps to avoid
+flakiness and ensure valid data flow verification (e.g. `rms_volume > 0`). Explicit struct initialization in tests prevents Clippy
 warnings and future-proofs against default value assumptions.
-**Action:** Implemented `audio_pipeline_tests.rs` with data flow, stats, and dropped sample verification. Refactored `trigger_system_tests.rs` 
+**Action:** Implemented `audio_pipeline_tests.rs` with data flow, stats, and dropped sample verification. Refactored `trigger_system_tests.rs`
 to use explicit `AudioTriggerData` initialization.
 
 ## 2024-05-27 - [Critical: Audio Sanitization & Zero-Size Transforms]
 
-**Erkenntnis:** `AudioAnalyzerV2` allowed NaN/Inf values to propagate, potentially destabilizing the entire audio pipeline. `ResizeMode` 
+**Erkenntnis:** `AudioAnalyzerV2` allowed NaN/Inf values to propagate, potentially destabilizing the entire audio pipeline. `ResizeMode`
 calculations for zero-sized layers could result in division by zero (Inf).
-**Aktion:** Implemented input sanitization in `AudioAnalyzerV2::process_samples` and zero-size checks in `ResizeMode::calculate_transform`. 
+**Aktion:** Implemented input sanitization in `AudioAnalyzerV2::process_samples` and zero-size checks in `ResizeMode::calculate_transform`.
 Added regression tests `test_resilience_to_bad_input` and `test_resize_mode_zero_size`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
  "bevy_pbr",
  "bevy_reflect",
  "bevy_render",
+ "bevy_sprite",
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
@@ -1007,10 +1008,13 @@ dependencies = [
  "bevy_reflect",
  "bevy_render",
  "bevy_scene",
+ "bevy_sprite",
  "bevy_state",
  "bevy_tasks",
+ "bevy_text",
  "bevy_time",
  "bevy_transform",
+ "bevy_ui",
  "bevy_utils",
  "bevy_window",
  "bevy_winit",
@@ -1298,6 +1302,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_sprite"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ccae7bab2cb956fb0434004c359e432a3a1a074a6ef4eb471f1fb099f0b620b"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_transform",
+ "bevy_utils",
+ "bitflags 2.10.0",
+ "bytemuck",
+ "derive_more",
+ "fixedbitset",
+ "nonmax",
+ "radsort",
+ "tracing",
+]
+
+[[package]]
 name = "bevy_state"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1378,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_text"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d76c85366159f5f54110f33321c76d8429cfd8f39638f26793a305dae568b60"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_log",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_sprite",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "cosmic-text",
+ "serde",
+ "smallvec",
+ "sys-locale",
+ "thiserror 2.0.18",
+ "tracing",
+ "unicode-bidi",
+]
+
+[[package]]
 name = "bevy_time"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1438,40 @@ dependencies = [
  "derive_more",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bevy_ui"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4a4d2ba51865bc3039af29a26b4f52c48b54cc758369f52004caf4b6f03770"
+dependencies = [
+ "accesskit 0.18.0",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_image",
+ "bevy_input",
+ "bevy_math",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_sprite",
+ "bevy_text",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
+ "bytemuck",
+ "derive_more",
+ "nonmax",
+ "smallvec",
+ "taffy",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -2136,6 +2232,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9504310988d938e49fff1b5f1e56e3dafe39bb1bae580c19660b58b83a191e"
 dependencies = [
  "core-foundation-sys",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e418dd4f5128c3e93eab12246391c54a20c496811131f85754dc8152ee207892"
+dependencies = [
+ "bitflags 2.10.0",
+ "fontdb 0.16.2",
+ "log",
+ "rangemap",
+ "rustc-hash 1.1.0",
+ "rustybuzz 0.14.1",
+ "self_cell",
+ "smol_str",
+ "swash",
+ "sys-locale",
+ "ttf-parser 0.21.1",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2948,12 +3067,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
  "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -2967,7 +3109,7 @@ dependencies = [
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -3361,6 +3503,12 @@ dependencies = [
  "lodepng",
  "png 0.17.16",
 ]
+
+[[package]]
+name = "grid"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
 
 [[package]]
 name = "guillotiere"
@@ -5457,7 +5605,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -6030,6 +6178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
 
 [[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6053,6 +6207,16 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -6464,6 +6628,23 @@ dependencies = [
 
 [[package]]
 name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser 0.21.1",
+ "unicode-bidi-mirroring 0.2.0",
+ "unicode-ccc 0.2.0",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "rustybuzz"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
@@ -6473,9 +6654,9 @@ dependencies = [
  "core_maths",
  "log",
  "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring 0.4.0",
+ "unicode-ccc 0.4.0",
  "unicode-properties",
  "unicode-script",
 ]
@@ -6715,6 +6896,16 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "skrifa"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
 
 [[package]]
 name = "slab"
@@ -6964,6 +7155,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "swash"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
+dependencies = [
+ "skrifa",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
 name = "symphonia"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7201,6 +7403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7233,6 +7444,18 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "taffy"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
 ]
 
 [[package]]
@@ -7807,6 +8030,18 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
@@ -7903,9 +8138,21 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-bidi-mirroring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ccc"
@@ -7918,6 +8165,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-properties"
@@ -8016,13 +8269,13 @@ dependencies = [
  "base64 0.22.1",
  "data-url",
  "flate2",
- "fontdb",
+ "fontdb 0.23.0",
  "imagesize 0.14.0",
  "kurbo 0.13.0",
  "log",
  "pico-args",
  "roxmltree 0.21.1",
- "rustybuzz",
+ "rustybuzz 0.20.1",
  "simplecss",
  "siphasher",
  "strict-num",
@@ -9461,6 +9714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
+name = "yazi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9482,6 +9741,12 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
+
+[[package]]
+name = "zeno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/crates/mapmap-bevy/Cargo.toml
+++ b/crates/mapmap-bevy/Cargo.toml
@@ -12,14 +12,16 @@ anyhow = { workspace = true }
 # Bevy 0.16 stabilization
 bevy = { version = "0.16", default-features = false, features = [
     "bevy_core_pipeline",
-    "bevy_pbr",
     "bevy_gltf",
+    "bevy_pbr",
     "bevy_render",
     "bevy_scene",
+    "bevy_text",
+    "bevy_ui",
     "bevy_winit",
-    "x11",
-    "wayland",
     "tonemapping_luts",
+    "wayland",
+    "x11",
 ] }
 
 # Extensions compatible with Bevy 0.16

--- a/crates/mapmap-bevy/src/components.rs
+++ b/crates/mapmap-bevy/src/components.rs
@@ -69,6 +69,26 @@ pub struct BevyParticles {
     pub color_end: [f32; 4],
 }
 
+#[derive(Reflect, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BevyTextAlignment {
+    #[default]
+    Center,
+    Left,
+    Right,
+    Justify,
+}
+
+#[derive(Component, Reflect, Default)]
+#[reflect(Component)]
+pub struct Bevy3DText {
+    pub text: String,
+    pub font_size: f32,
+    pub color: [f32; 4],
+    pub position: [f32; 3],
+    pub rotation: [f32; 3],
+    pub alignment: BevyTextAlignment,
+}
+
 /// Tag component for the Shared Engine instance
 #[derive(Component)]
 pub struct SharedEngineCamera;

--- a/crates/mapmap-bevy/src/lib.rs
+++ b/crates/mapmap-bevy/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod components;
 pub mod resources;
 pub mod systems;
+pub mod text;
 
 use bevy::prelude::*;
 use components::*;
@@ -32,26 +33,26 @@ impl BevyRunner {
         let mut app = App::new();
 
         // Use DefaultPlugins but disable windowing and input loop to avoid Winit panic
-        app.add_plugins(DefaultPlugins
-            .set(WindowPlugin {
-                primary_window: None,
-                exit_condition: bevy::window::ExitCondition::DontExit,
-                close_when_requested: false,
-            })
-            .set(bevy::render::RenderPlugin {
-                render_creation: bevy::render::settings::RenderCreation::Automatic(
-                    bevy::render::settings::WgpuSettings {
-                        // Inherit backend preferences if possible, or default
-                        ..default()
-                    }
-                ),
-                synchronous_pipeline_compilation: false,
-                ..default()
-            })
-            // CRITICAL: Disable WinitPlugin to prevent it from taking over the event loop!
-            .disable::<bevy::winit::WinitPlugin>()
+        app.add_plugins(
+            DefaultPlugins
+                .set(WindowPlugin {
+                    primary_window: None,
+                    exit_condition: bevy::window::ExitCondition::DontExit,
+                    close_when_requested: false,
+                })
+                .set(bevy::render::RenderPlugin {
+                    render_creation: bevy::render::settings::RenderCreation::Automatic(
+                        bevy::render::settings::WgpuSettings {
+                            // Inherit backend preferences if possible, or default
+                            ..default()
+                        },
+                    ),
+                    synchronous_pipeline_compilation: false,
+                    ..default()
+                })
+                // CRITICAL: Disable WinitPlugin to prevent it from taking over the event loop!
+                .disable::<bevy::winit::WinitPlugin>(),
         );
-
 
         // Register Extensions (Temporarily disabled due to version mismatch)
         // app.add_plugins(bevy_enoki::EnokiPlugin);
@@ -73,12 +74,18 @@ impl BevyRunner {
         app.register_type::<BevyAtmosphere>();
         app.register_type::<BevyHexGrid>();
         app.register_type::<BevyParticles>();
+        app.register_type::<Bevy3DText>();
 
         // Register systems
         app.add_systems(Startup, setup_3d_scene);
         app.add_systems(
             Update,
-            (print_status_system, audio_reaction_system, hex_grid_system),
+            (
+                print_status_system,
+                audio_reaction_system,
+                hex_grid_system,
+                text::text_system,
+            ),
         ); // Removed sync_atmosphere_system, particle_system
 
         // Add readback system to the RENDER APP, not the main app
@@ -191,6 +198,42 @@ impl BevyRunner {
                                     p.speed = *speed;
                                     p.color_start = *color_start;
                                     p.color_end = *color_end;
+                                }
+                            }
+                            SourceType::Bevy3DText {
+                                text,
+                                font_size,
+                                color,
+                                position,
+                                rotation,
+                                alignment,
+                            } => {
+                                let entity =
+                                    *mapping.entities.entry(part.id).or_insert_with(|| {
+                                        world.spawn(crate::components::Bevy3DText::default()).id()
+                                    });
+                                if let Some(mut comp) =
+                                    world.get_mut::<crate::components::Bevy3DText>(entity)
+                                {
+                                    comp.text = text.clone();
+                                    comp.font_size = *font_size;
+                                    comp.color = *color;
+                                    comp.position = *position;
+                                    comp.rotation = *rotation;
+                                    comp.alignment = match alignment {
+                                        mapmap_core::module::TextAlignmentType::Left => {
+                                            crate::components::BevyTextAlignment::Left
+                                        }
+                                        mapmap_core::module::TextAlignmentType::Center => {
+                                            crate::components::BevyTextAlignment::Center
+                                        }
+                                        mapmap_core::module::TextAlignmentType::Right => {
+                                            crate::components::BevyTextAlignment::Right
+                                        }
+                                        mapmap_core::module::TextAlignmentType::Justify => {
+                                            crate::components::BevyTextAlignment::Justify
+                                        }
+                                    };
                                 }
                             }
                             _ => {}

--- a/crates/mapmap-bevy/src/text.rs
+++ b/crates/mapmap-bevy/src/text.rs
@@ -1,0 +1,47 @@
+use crate::components::{Bevy3DText, BevyTextAlignment};
+use bevy::prelude::*;
+use bevy::text::{JustifyText, Text2d, TextColor, TextFont, TextLayout};
+
+pub fn text_system(
+    mut commands: Commands,
+    query: Query<(Entity, &Bevy3DText), Changed<Bevy3DText>>,
+) {
+    for (entity, config) in query.iter() {
+        let justify = match config.alignment {
+            BevyTextAlignment::Left => JustifyText::Left,
+            BevyTextAlignment::Center => JustifyText::Center,
+            BevyTextAlignment::Right => JustifyText::Right,
+            BevyTextAlignment::Justify => JustifyText::Justified,
+        };
+
+        let color = Color::srgba(
+            config.color[0],
+            config.color[1],
+            config.color[2],
+            config.color[3],
+        );
+
+        let rotation = Quat::from_euler(
+            EulerRot::XYZ,
+            config.rotation[0].to_radians(),
+            config.rotation[1].to_radians(),
+            config.rotation[2].to_radians(),
+        );
+
+        commands.entity(entity).insert((
+            Text::new(config.text.clone()),
+            TextFont {
+                font_size: config.font_size,
+                ..default()
+            },
+            TextColor(color),
+            TextLayout {
+                justify,
+                ..default()
+            },
+            Text2d::default(),
+            Transform::from_xyz(config.position[0], config.position[1], config.position[2])
+                .with_rotation(rotation),
+        ));
+    }
+}

--- a/crates/mapmap-core/src/module.rs
+++ b/crates/mapmap-core/src/module.rs
@@ -1135,6 +1135,24 @@ pub enum SourceType {
         /// Transform: Rotation [x, y, z] in degrees
         rotation: [f32; 3],
     },
+    /// Specialized Bevy 3D Text Node
+    Bevy3DText {
+        /// Text content
+        text: String,
+        /// Font size
+        #[serde(default = "default_font_size")]
+        font_size: f32,
+        /// Text color (RGBA)
+        #[serde(default = "default_text_color")]
+        color: [f32; 4],
+        /// Transform: Position [x, y, z]
+        position: [f32; 3],
+        /// Transform: Rotation [x, y, z] in degrees
+        rotation: [f32; 3],
+        /// Text alignment
+        #[serde(default)]
+        alignment: TextAlignmentType,
+    },
     /// Spout shared texture (Windows only)
     #[cfg(target_os = "windows")]
     SpoutInput {
@@ -1349,6 +1367,28 @@ pub enum SourceType {
         #[serde(default)]
         flip_vertical: bool,
     },
+}
+
+fn default_font_size() -> f32 {
+    32.0
+}
+
+fn default_text_color() -> [f32; 4] {
+    [1.0, 1.0, 1.0, 1.0]
+}
+
+/// Text alignment options
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum TextAlignmentType {
+    /// Align text to the left
+    Left,
+    /// Align text to the center
+    #[default]
+    Center,
+    /// Align text to the right
+    Right,
+    /// Justify text
+    Justify,
 }
 
 impl SourceType {

--- a/crates/mapmap-core/src/module_eval.rs
+++ b/crates/mapmap-core/src/module_eval.rs
@@ -1366,6 +1366,7 @@ impl ModuleEvaluator {
             SourceType::BevyAtmosphere { .. } => Some(SourceCommand::BevyInput { trigger_value }),
             SourceType::BevyHexGrid { .. } => Some(SourceCommand::BevyInput { trigger_value }),
             SourceType::BevyParticles { .. } => Some(SourceCommand::BevyInput { trigger_value }),
+            SourceType::Bevy3DText { .. } => Some(SourceCommand::BevyInput { trigger_value }),
             SourceType::Bevy => Some(SourceCommand::BevyInput { trigger_value }),
         }
     }

--- a/crates/mapmap-ui/src/editors/module_canvas.rs
+++ b/crates/mapmap-ui/src/editors/module_canvas.rs
@@ -901,6 +901,7 @@ impl ModuleCanvas {
                                                 SourceType::BevyAtmosphere { .. } => "☁️ Atmosphere",
                                                 SourceType::BevyHexGrid { .. } => "🛑 Hex Grid",
                                                 SourceType::BevyParticles { .. } => "✨ Particles",
+                                                SourceType::Bevy3DText { .. } => "📝 3D Text",
                                             };
 
                                             let mut next_type = None;
@@ -915,6 +916,9 @@ impl ModuleCanvas {
                                                     ui.label("--- Shared ---");
                                                     if ui.selectable_label(matches!(source, SourceType::VideoMulti { .. }), "🔗 Video (Multi)").clicked() { next_type = Some("VideoMulti"); }
                                                     if ui.selectable_label(matches!(source, SourceType::ImageMulti { .. }), "🔗 Image (Multi)").clicked() { next_type = Some("ImageMulti"); }
+
+                                                    ui.label("--- Bevy ---");
+                                                    if ui.selectable_label(matches!(source, SourceType::Bevy3DText { .. }), "📝 3D Text").clicked() { next_type = Some("Bevy3DText"); }
                                                 });
 
                                             if let Some(t) = next_type {
@@ -958,6 +962,14 @@ impl ModuleCanvas {
                                                         opacity: 1.0, blend_mode: None, brightness: 0.0, contrast: 1.0, saturation: 1.0, hue_shift: 0.0,
                                                         scale_x: 1.0, scale_y: 1.0, rotation: 0.0, offset_x: 0.0, offset_y: 0.0,
                                                         flip_horizontal: false, flip_vertical: false,
+                                                    },
+                                                    "Bevy3DText" => SourceType::Bevy3DText {
+                                                        text: "Hello World".to_string(),
+                                                        font_size: 32.0,
+                                                        color: [1.0, 1.0, 1.0, 1.0],
+                                                        position: [0.0, 0.0, 0.0],
+                                                        rotation: [0.0, 0.0, 0.0],
+                                                        alignment: Default::default(),
                                                     },
                                                     _ => source.clone(),
                                                 };
@@ -1352,6 +1364,58 @@ impl ModuleCanvas {
                                                 ui.label("🎮 Bevy Scene");
                                                 ui.label(egui::RichText::new("Rendering Internal 3D Scene").weak());
                                                 ui.small("The scene is rendered internally and available as 'bevy_output'");
+                                            }
+                                            SourceType::Bevy3DText {
+                                                text,
+                                                font_size,
+                                                color,
+                                                position,
+                                                rotation,
+                                                alignment,
+                                            } => {
+                                                ui.label("📝 Bevy 3D Text");
+                                                ui.separator();
+
+                                                ui.label("Content:");
+                                                ui.add(egui::TextEdit::multiline(text).desired_rows(2));
+
+                                                ui.horizontal(|ui| {
+                                                    ui.label("Size:");
+                                                    ui.add(egui::Slider::new(font_size, 8.0..=200.0));
+                                                });
+
+                                                ui.horizontal(|ui| {
+                                                    ui.label("Color:");
+                                                    ui.color_edit_button_rgba_unmultiplied(color);
+                                                });
+
+                                                ui.horizontal(|ui| {
+                                                    ui.label("Align:");
+                                                    egui::ComboBox::from_id_salt(format!("align_{}", part_id))
+                                                        .selected_text(format!("{:?}", alignment))
+                                                        .show_ui(ui, |ui| {
+                                                            use mapmap_core::module::TextAlignmentType;
+                                                            ui.selectable_value(alignment, TextAlignmentType::Left, "Left");
+                                                            ui.selectable_value(alignment, TextAlignmentType::Center, "Center");
+                                                            ui.selectable_value(alignment, TextAlignmentType::Right, "Right");
+                                                            ui.selectable_value(alignment, TextAlignmentType::Justify, "Justify");
+                                                        });
+                                                });
+
+                                                ui.collapsing("Transform 3D", |ui| {
+                                                    ui.horizontal(|ui| {
+                                                        ui.label("Pos:");
+                                                        ui.add(egui::DragValue::new(&mut position[0]).speed(0.1).prefix("X:"));
+                                                        ui.add(egui::DragValue::new(&mut position[1]).speed(0.1).prefix("Y:"));
+                                                        ui.add(egui::DragValue::new(&mut position[2]).speed(0.1).prefix("Z:"));
+                                                    });
+                                                    ui.horizontal(|ui| {
+                                                        ui.label("Rot:");
+                                                        ui.add(egui::DragValue::new(&mut rotation[0]).speed(1.0).prefix("X:").suffix("°"));
+                                                        ui.add(egui::DragValue::new(&mut rotation[1]).speed(1.0).prefix("Y:").suffix("°"));
+                                                        ui.add(egui::DragValue::new(&mut rotation[2]).speed(1.0).prefix("Z:").suffix("°"));
+                                                    });
+                                                });
                                             }
 
                                         }
@@ -5252,6 +5316,12 @@ impl ModuleCanvas {
                 "✨",
                 "Particles",
             ),
+            ModulePartType::Source(SourceType::Bevy3DText { .. }) => (
+                Color32::from_rgb(40, 60, 80),
+                Color32::from_rgb(100, 180, 220),
+                "📝",
+                "3D Text",
+            ),
             ModulePartType::Source(source) => {
                 let name = match source {
                     SourceType::MediaFile { .. } => "Media File",
@@ -5268,6 +5338,7 @@ impl ModuleCanvas {
                     SourceType::BevyAtmosphere { .. } => "Atmosphere",
                     SourceType::BevyHexGrid { .. } => "Hex Grid",
                     SourceType::BevyParticles { .. } => "Particles",
+                    SourceType::Bevy3DText { .. } => "3D Text",
                 };
                 (
                     Color32::from_rgb(50, 60, 70),
@@ -5474,6 +5545,9 @@ impl ModuleCanvas {
                 SourceType::BevyAtmosphere { .. } => "☁️ Atmosphere".to_string(),
                 SourceType::BevyHexGrid { .. } => "🛑 Hex Grid".to_string(),
                 SourceType::BevyParticles { .. } => "✨ Particles".to_string(),
+                SourceType::Bevy3DText { text, .. } => {
+                    format!("📝 Text: {}", text.chars().take(10).collect::<String>())
+                }
             },
             ModulePartType::Mask(mask_type) => match mask_type {
                 MaskType::File { path } => {

--- a/docs/03-FEATURES/BEVY_NODES/BEVY_3D_TEXT.md
+++ b/docs/03-FEATURES/BEVY_NODES/BEVY_3D_TEXT.md
@@ -1,0 +1,28 @@
+# Bevy 3D Text Node
+
+The **Bevy 3D Text Node** allows you to render text within the 3D Bevy scene. It provides controls for content, styling, and 3D transformation.
+
+## Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| **Text** | String | The actual text content to display. | "" |
+| **Font Size** | Float | Size of the text font. | 32.0 |
+| **Color** | Color (RGBA) | Color of the text. | White (1.0, 1.0, 1.0, 1.0) |
+| **Position** | Vector3 | 3D position [X, Y, Z] in the scene. | [0.0, 0.0, 0.0] |
+| **Rotation** | Vector3 | 3D rotation [X, Y, Z] in degrees (Euler angles). | [0.0, 0.0, 0.0] |
+| **Alignment** | Enum | Text alignment (Left, Center, Right, Justify). | Center |
+
+## Usage
+
+1.  Add a **Bevy 3D Text** node to your MapFlow graph (under Sources -> Bevy).
+2.  Connect its `Media Out` to a layer or effect chain.
+3.  Adjust the `Text` field to change the message.
+4.  Use `Position` and `Rotation` to place the text in the 3D world relative to the camera.
+5.  Use `Font Size` and `Color` to style the text.
+
+## Notes
+
+*   This node uses the default Bevy font (`FiraMono-Medium.ttf` if available via `bevy_text` feature).
+*   The text is rendered as a 2D plane (billboard) in the 3D world (`Text2d`), not as extruded 3D geometry.
+*   Performance is generally high, but spawning thousands of text nodes may have an impact.

--- a/docs/05-DEVELOPMENT/REFACTORING_PLAN.md
+++ b/docs/05-DEVELOPMENT/REFACTORING_PLAN.md
@@ -1,6 +1,6 @@
 # Refactoring Plan: `main.rs` Decomposition & Architecture
 
-This document serves as the master plan for refactoring the MapMap application. It is broken down into specific, actionable 
+This document serves as the master plan for refactoring the MapMap application. It is broken down into specific, actionable
 "Jules Tasks" that are self-contained and verifiable.
 
 ## 🎯 Strategic Goals


### PR DESCRIPTION
This update addresses the CI quality check failures reported in the previous run.
I have run `cargo clippy --fix` across the workspace to resolve the linter warnings, specifically ensuring that the new `Bevy3DText` implementation adheres to the project's coding standards.

---
*PR created automatically by Jules for task [15247751561824778070](https://jules.google.com/task/15247751561824778070) started by @MrLongNight*