### PR TITLE
⚡ Bolt: Optimize particle RNG and frame readback buffer reuse

### DIFF
--- a/crates/mapmap-bevy/src/systems.rs
+++ b/crates/mapmap-bevy/src/systems.rs
@@ -203,36 +203,38 @@ pub fn particle_system(
 
         // Spawn new particles
         emitter.spawn_accumulator += config.rate * delta_time;
-        while emitter.spawn_accumulator > 1.0 {
-            emitter.spawn_accumulator -= 1.0;
-
+        if emitter.spawn_accumulator > 1.0 {
             let mut rng = rand::rng();
-            let velocity = Vec3::new(
-                rng.random_range(-1.0..1.0),
-                rng.random_range(-1.0..1.0),
-                rng.random_range(-1.0..1.0),
-            )
-            .normalize_or_zero()
-                * config.speed;
+            while emitter.spawn_accumulator > 1.0 {
+                emitter.spawn_accumulator -= 1.0;
 
-            emitter.particles.push(crate::components::Particle {
-                position: Vec3::ZERO, // Relative to entity transform
-                velocity,
-                lifetime: config.lifetime,
-                age: 0.0,
-                color_start: LinearRgba::new(
-                    config.color_start[0],
-                    config.color_start[1],
-                    config.color_start[2],
-                    config.color_start[3],
-                ),
-                color_end: LinearRgba::new(
-                    config.color_end[0],
-                    config.color_end[1],
-                    config.color_end[2],
-                    config.color_end[3],
-                ),
-            });
+                let velocity = Vec3::new(
+                    rng.random_range(-1.0..1.0),
+                    rng.random_range(-1.0..1.0),
+                    rng.random_range(-1.0..1.0),
+                )
+                .normalize_or_zero()
+                    * config.speed;
+
+                emitter.particles.push(crate::components::Particle {
+                    position: Vec3::ZERO, // Relative to entity transform
+                    velocity,
+                    lifetime: config.lifetime,
+                    age: 0.0,
+                    color_start: LinearRgba::new(
+                        config.color_start[0],
+                        config.color_start[1],
+                        config.color_start[2],
+                        config.color_start[3],
+                    ),
+                    color_end: LinearRgba::new(
+                        config.color_end[0],
+                        config.color_end[1],
+                        config.color_end[2],
+                        config.color_end[3],
+                    ),
+                });
+            }
         }
 
         // Update particles
@@ -304,6 +306,7 @@ pub fn frame_readback_system(
     render_output: Res<crate::resources::BevyRenderOutput>,
     render_device: Res<bevy::render::renderer::RenderDevice>,
     render_queue: Res<bevy::render::renderer::RenderQueue>,
+    mut buffer_cache: Local<Option<bevy::render::render_resource::Buffer>>,
 ) {
     if let Some(gpu_image) = gpu_images.get(&render_output.image_handle) {
         let texture = &gpu_image.texture;
@@ -320,14 +323,20 @@ pub fn frame_readback_system(
 
         let output_buffer_size = (bytes_per_row * height) as u64;
 
-        let buffer =
-            render_device.create_buffer(&bevy::render::render_resource::BufferDescriptor {
-                label: Some("Readback Buffer"),
-                size: output_buffer_size,
-                usage: bevy::render::render_resource::BufferUsages::MAP_READ
-                    | bevy::render::render_resource::BufferUsages::COPY_DST,
-                mapped_at_creation: false,
-            });
+        // Ensure buffer exists and is correct size
+        if buffer_cache.is_none() || buffer_cache.as_ref().unwrap().size() != output_buffer_size {
+            *buffer_cache = Some(render_device.create_buffer(
+                &bevy::render::render_resource::BufferDescriptor {
+                    label: Some("Readback Buffer"),
+                    size: output_buffer_size,
+                    usage: bevy::render::render_resource::BufferUsages::MAP_READ
+                        | bevy::render::render_resource::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                },
+            ));
+        }
+
+        let buffer = buffer_cache.as_ref().unwrap();
 
         let mut encoder = render_device.create_command_encoder(
             &bevy::render::render_resource::CommandEncoderDescriptor {
@@ -343,7 +352,7 @@ pub fn frame_readback_system(
                 aspect: bevy::render::render_resource::TextureAspect::All,
             },
             bevy::render::render_resource::TexelCopyBufferInfo {
-                buffer: &buffer,
+                buffer,
                 layout: bevy::render::render_resource::TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(bytes_per_row),
@@ -389,5 +398,8 @@ pub fn frame_readback_system(
                 }
             }
         }
+
+        // Must unmap to use buffer again next frame for writing
+        buffer.unmap();
     }
 }


### PR DESCRIPTION
This PR implements two performance optimizations in `mapmap-bevy`:
1.  **Particle System Optimization**: The random number generator is now initialized once per frame (if needed) rather than for every single particle spawned. This reduces CPU overhead during high-rate particle emission.
2.  **Frame Readback Optimization**: The `frame_readback_system` now uses a `Local` cache to store and reuse the `wgpu` staging buffer. Previously, a new buffer was allocated and destroyed every frame (approx. 3.6MB for 720p), causing significant memory churn and driver overhead. The new implementation reuses the buffer as long as the resolution matches, only unmapping it after reading to prepare for the next frame.

These changes improve CPU efficiency and reduce memory pressure on the GPU driver.

---
*PR created automatically by Jules for task [10209619805397057878](https://jules.google.com/task/10209619805397057878) started by @MrLongNight*