### PR TITLE
🛡️ Sentinel: Fix sensitive data exposure in HueConfig Debug

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** Browser-based WebSocket clients could not authenticate with the API server because the `extract_api_key` logic relied on standard HTTP headers (`Authorization`, `X-API-Key`) which browsers cannot set for WebSocket connections. This forced developers to potentially disable authentication for WebSocket endpoints.
 **Learning:** Browser WebSocket APIs are restrictive. Authentication tokens must be transmitted via the `Sec-WebSocket-Protocol` header (subprotocol negotiation) as a standard workaround.
 **Prevention:** Always support `Sec-WebSocket-Protocol` parsing in API key extraction logic for WebSocket endpoints. Implement specific parsing for custom subprotocol formats (e.g., `mapmap.auth.<TOKEN>`).
+
+## 2026-01-29 - Sensitive Data Exposure in Debug Logs
+**Vulnerability:** The `HueConfig` struct in `mapmap-control` and `mapmap-ui` implemented `Debug` via `derive`, which exposed sensitive credentials (`client_key`, `username`) in debug logs. This pattern is common but dangerous for structs containing secrets.
+**Learning:** `derive(Debug)` is convenient but automatically prints all fields. For configuration structs holding API keys, passwords, or tokens, this inadvertently leaks secrets to anyone with access to application logs.
+**Prevention:** Always manually implement `std::fmt::Debug` for structs containing sensitive data. Use `.field("secret", &"***REDACTED***")` to mask these fields while keeping the struct debuggable. Add unit tests to verify redaction.

--- a/crates/mapmap-control/src/hue/models.rs
+++ b/crates/mapmap-control/src/hue/models.rs
@@ -1,12 +1,51 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct HueConfig {
     pub bridge_ip: String,
     pub username: String,       // Used as "hue-application-key" in REST headers
     pub client_key: String,     // Used as PSK for DTLS encryption
     pub application_id: String, // Used as PSK Identity for DTLS (from /auth/v1)
     pub entertainment_group_id: String,
+}
+
+impl std::fmt::Debug for HueConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HueConfig")
+            .field("bridge_ip", &self.bridge_ip)
+            .field("username", &"***REDACTED***")
+            .field("client_key", &"***REDACTED***")
+            .field("application_id", &self.application_id)
+            .field("entertainment_group_id", &self.entertainment_group_id)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hue_config_debug_redaction() {
+        let config = HueConfig {
+            bridge_ip: "192.168.1.5".to_string(),
+            username: "secret_user_123".to_string(),
+            client_key: "secret_key_456".to_string(),
+            application_id: "app_789".to_string(),
+            entertainment_group_id: "group_001".to_string(),
+        };
+        let debug_str = format!("{:?}", config);
+
+        // Assert sensitive fields are redacted
+        assert!(debug_str.contains("***REDACTED***"));
+        assert!(!debug_str.contains("secret_user_123"));
+        assert!(!debug_str.contains("secret_key_456"));
+
+        // Assert non-sensitive fields are present
+        assert!(debug_str.contains("192.168.1.5"));
+        assert!(debug_str.contains("app_789"));
+        assert!(debug_str.contains("group_001"));
+    }
 }
 
 /// Represents a light channel in an entertainment configuration.

--- a/crates/mapmap-ui/src/core/config.rs
+++ b/crates/mapmap-ui/src/core/config.rs
@@ -75,7 +75,7 @@ pub struct MidiAssignment {
 }
 
 /// Configuration for Philips Hue integration
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct HueConfig {
     /// Bridge IP address
     #[serde(default)]
@@ -92,6 +92,18 @@ pub struct HueConfig {
     /// Setup mode/auto-connect
     #[serde(default)]
     pub auto_connect: bool,
+}
+
+impl std::fmt::Debug for HueConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HueConfig")
+            .field("bridge_ip", &self.bridge_ip)
+            .field("username", &"***REDACTED***")
+            .field("client_key", &"***REDACTED***")
+            .field("entertainment_area", &self.entertainment_area)
+            .field("auto_connect", &self.auto_connect)
+            .finish()
+    }
 }
 
 /// User configuration settings
@@ -341,6 +353,22 @@ mod tests {
         let config = UserConfig::default();
         assert_eq!(config.language, "en");
         assert!(config.recent_files.is_empty());
+    }
+
+    #[test]
+    fn test_hue_config_debug_redaction() {
+        let config = HueConfig {
+            bridge_ip: "10.0.0.5".to_string(),
+            username: "secret_user".to_string(),
+            client_key: "secret_key".to_string(),
+            entertainment_area: "area_1".to_string(),
+            auto_connect: true,
+        };
+        let debug_str = format!("{:?}", config);
+        assert!(debug_str.contains("***REDACTED***"));
+        assert!(!debug_str.contains("secret_user"));
+        assert!(!debug_str.contains("secret_key"));
+        assert!(debug_str.contains("10.0.0.5"));
     }
 
     #[test]


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in HueConfig Debug

🚨 Severity: HIGH
💡 Vulnerability: `HueConfig` structs in `mapmap-control` and `mapmap-ui` implemented `Debug` via `derive`, which exposed sensitive credentials (`username` as API key, `client_key` as DTLS PSK) in debug logs.
🎯 Impact: Anyone with access to application logs (e.g., via `RUST_LOG=debug` or crash reports) could obtain full control over the user's Hue Bridge entertainment area.
🔧 Fix: Removed `derive(Debug)` and manually implemented `std::fmt::Debug` to redact sensitive fields with `"***REDACTED***"`.
✅ Verification: Added unit tests `test_hue_config_debug_redaction` in both crates to ensure sensitive fields are redacted and non-sensitive fields remain visible. Validated with `cargo test`.

---
*PR created automatically by Jules for task [3937644747424839256](https://jules.google.com/task/3937644747424839256) started by @MrLongNight*