### PR TITLE
🛡️ Sentinel: [HIGH] Add missing Cache-Control headers to API responses

### DIFF
--- a/crates/mapmap-control/src/web/server.rs
+++ b/crates/mapmap-control/src/web/server.rs
@@ -269,6 +269,14 @@ async fn security_headers(req: Request, next: Next) -> Response {
         HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
     );
 
+    // Cache Control
+    // Prevent caching of sensitive responses
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, max-age=0"),
+    );
+    headers.insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+
     response
 }
 
@@ -360,6 +368,14 @@ mod tests {
                 .get("Strict-Transport-Security")
                 .and_then(|h| h.to_str().ok()),
             Some("max-age=63072000; includeSubDomains; preload")
+        );
+        assert_eq!(
+            headers.get("Cache-Control").and_then(|h| h.to_str().ok()),
+            Some("no-store, max-age=0")
+        );
+        assert_eq!(
+            headers.get("Pragma").and_then(|h| h.to_str().ok()),
+            Some("no-cache")
         );
     }
 }


### PR DESCRIPTION
Adds Cache-Control: no-store, max-age=0 and Pragma: no-cache headers to the mapmap-control web server to prevent sensitive API data from being cached by browsers or proxies. This aligns with security best practices for API responses.

Verification:
- Added unit tests in `server.rs` to verify headers are present.
- Verified that existing tests pass.
- Verified code formatting and linting.

---
*PR created automatically by Jules for task [8959687106302799649](https://jules.google.com/task/8959687106302799649) started by @MrLongNight*