### PR TITLE
🛡️ Sentinel: Add anti-caching security headers

### DIFF
--- a/crates/mapmap-control/src/web/server.rs
+++ b/crates/mapmap-control/src/web/server.rs
@@ -269,6 +269,14 @@ async fn security_headers(req: Request, next: Next) -> Response {
         HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
     );
 
+    // Cache Control
+    // Prevent caching of sensitive API responses
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, max-age=0"),
+    );
+    headers.insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+
     response
 }
 
@@ -360,6 +368,14 @@ mod tests {
                 .get("Strict-Transport-Security")
                 .and_then(|h| h.to_str().ok()),
             Some("max-age=63072000; includeSubDomains; preload")
+        );
+        assert_eq!(
+            headers.get("Cache-Control").and_then(|h| h.to_str().ok()),
+            Some("no-store, max-age=0")
+        );
+        assert_eq!(
+            headers.get("Pragma").and_then(|h| h.to_str().ok()),
+            Some("no-cache")
         );
     }
 }


### PR DESCRIPTION
Adds `Cache-Control` and `Pragma` headers to the `security_headers` middleware in `mapmap-control`. This ensures that sensitive API responses are not cached, aligning with security best practices. Verified with updated unit tests.

---
*PR created automatically by Jules for task [13596854292112969068](https://jules.google.com/task/13596854292112969068) started by @MrLongNight*