### PR TITLE
⚡ Bolt: Remove O(N) HashMap allocation in render loop

### DIFF
--- a/crates/mapmap-core/src/module_eval.rs
+++ b/crates/mapmap-core/src/module_eval.rs
@@ -819,12 +819,8 @@ impl ModuleEvaluator {
         let mut source_props = SourceProperties::default_identity();
         let mut current_id = start_node_id;
 
-        // CRITICAL: Ensure the part index cache is consistent with the current module state
-        let mut part_index = std::collections::HashMap::new();
-        for (i, part) in module.parts.iter().enumerate() {
-            part_index.insert(part.id, i);
-        }
-
+        // Use cached index from evaluate phase.
+        // Note: This requires that evaluate() has been called for this module to populate self.part_index_cache.
         tracing::debug!(
             "trace_chain: Starting from node {} in module {}",
             start_node_id,
@@ -837,7 +833,7 @@ impl ModuleEvaluator {
         for _iteration in 0..50 {
             // Apply Trigger Targets for the current node
             // We need to find if any input sockets have triggers active and targets mapped
-            if let Some(&part_idx) = part_index.get(&current_id) {
+            if let Some(&part_idx) = self.part_index_cache.get(&current_id) {
                 let part = &module.parts[part_idx];
 
                 // Check if any *incoming* connection determines the value?
@@ -919,7 +915,7 @@ impl ModuleEvaluator {
                 .copied()
             {
                 let conn = &module.connections[conn_idx];
-                if let Some(&part_idx) = part_index.get(&conn.from_part) {
+                if let Some(&part_idx) = self.part_index_cache.get(&conn.from_part) {
                     let part = &module.parts[part_idx];
                     match &part.part_type {
                         ModulePartType::Source(source_type) => {


### PR DESCRIPTION
💡 What: Removed redundant `HashMap` creation in `trace_chain` which runs for every layer every frame.
🎯 Why: `trace_chain` was allocating and populating a map of all module parts on every call, despite `evaluate` already building and caching this map in `self.part_index_cache`.
📊 Impact: Reduces allocations by N per frame (where N is number of layers). For complex graphs, this avoids thousands of unnecessary map insertions per second.
🔬 Measurement: Verified with unit tests `cargo test -p mapmap-core`.

---
*PR created automatically by Jules for task [16436290555298834712](https://jules.google.com/task/16436290555298834712) started by @MrLongNight*