### PR TITLE
🎨 UI: Update Inspector and Audio panels to Cyber Dark theme

### DIFF
--- a/.jules/lina-styleui.md
+++ b/.jules/lina-styleui.md
@@ -46,3 +46,12 @@
     - **Node Header:** `colors::LIGHTER_GREY` (creates contrast vs body).
     - **Separator:** `colors::STROKE_GREY` (sharp definition).
 **Action:** Refactored `ModuleCanvas` to use `crate::theme::colors` constants, enforcing the Cyber Dark palette on the node graph.
+
+## 2026-02-02 – [Sharp Corners & Borders]
+**Learning:** To fully align with the "Cyber Dark" (Resolume/MadMapper) aesthetic, UI elements must avoid rounded corners.
+- **Insight:** Rounded corners soften the interface, while sharp corners (`corner_radius: 0.0`) and defined borders (`STROKE_GREY`) create a more technical, precise look suitable for VJ software.
+- **Pattern:**
+    - **Panels/Sections:** Use `egui::Frame` with `corner_radius(0.0)` and `stroke(Stroke::new(1.0, colors::STROKE_GREY))`.
+    - **Bars/Meters:** Use `painter.rect_filled` with rounding `0.0`.
+    - **Frames:** Explicitly override default frame rounding.
+**Action:** Refactored `InspectorPanel` (sections) and `AudioPanel` (visualizations) to enforce this sharp, bordered style.

--- a/crates/mapmap-ui/src/panels/audio_panel.rs
+++ b/crates/mapmap-ui/src/panels/audio_panel.rs
@@ -193,6 +193,7 @@ impl AudioPanel {
             egui::Frame::default()
                 .fill(colors::DARKER_GREY)
                 .stroke(Stroke::new(1.0, colors::STROKE_GREY))
+                .corner_radius(0.0)
                 .inner_margin(4.0)
                 .show(ui, |ui| match self.view_mode {
                     ViewMode::Spectrum => self.render_spectrum(ui, analysis),
@@ -231,10 +232,10 @@ impl AudioPanel {
         let painter = ui.painter();
 
         // Background
-        painter.rect_filled(rect, 2.0, colors::DARKER_GREY);
+        painter.rect_filled(rect, 0.0, colors::DARKER_GREY);
         painter.rect_stroke(
             rect,
-            egui::CornerRadius::same(2),
+            egui::CornerRadius::ZERO,
             Stroke::new(1.0, colors::STROKE_GREY),
             egui::StrokeKind::Middle,
         );
@@ -252,7 +253,7 @@ impl AudioPanel {
             colors::MINT_ACCENT
         };
 
-        painter.rect_filled(bar_rect, 2.0, color);
+        painter.rect_filled(bar_rect, 0.0, color);
 
         // Text
         painter.text(
@@ -389,7 +390,7 @@ impl AudioPanel {
                 colors::CYAN_ACCENT
             };
 
-            painter.rect_filled(bar_rect, 2.0, color);
+            painter.rect_filled(bar_rect, 0.0, color);
 
             // Peak indicator
             let peak_y = rect.max.y

--- a/crates/mapmap-ui/src/panels/inspector_panel.rs
+++ b/crates/mapmap-ui/src/panels/inspector_panel.rs
@@ -352,7 +352,8 @@ fn inspector_section(
             egui::Frame::NONE
                 .fill(colors::LIGHTER_GREY)
                 .inner_margin(8.0)
-                .corner_radius(4.0)
+                .corner_radius(0.0)
+                .stroke(egui::Stroke::new(1.0, colors::STROKE_GREY))
                 .show(ui, |ui| {
                     ui.set_min_width(ui.available_width());
                     add_contents(ui);


### PR DESCRIPTION
This PR updates the visual style of the `InspectorPanel` and `AudioPanel` to match the "Cyber Dark" theme guidelines.

Changes:
- **InspectorPanel:** Used `egui::Frame` with `corner_radius(0.0)` and `stroke(colors::STROKE_GREY)` for property sections.
- **AudioPanel:** Updated the main visualization frame, RMS volume bar, and frequency band meters to use sharp corners (`0.0`).
- **Journal:** Documented the "Sharp Corners & Borders" rule in `.jules/lina-styleui.md`.

This ensures a more technical and consistent look across the application, removing "soft" rounded UI elements where they don't fit the VJ software aesthetic.

---
*PR created automatically by Jules for task [15273757134262959205](https://jules.google.com/task/15273757134262959205) started by @MrLongNight*