### PR TITLE
⚡ Bolt: Hoist RNG initialization in TriggerSystem::update

### DIFF
--- a/crates/mapmap-core/src/trigger_system.rs
+++ b/crates/mapmap-core/src/trigger_system.rs
@@ -2,6 +2,7 @@
 
 use crate::audio_reactive::AudioTriggerData;
 use crate::module::{ModuleManager, ModulePartType, TriggerType};
+use rand::Rng;
 use std::collections::{HashMap, HashSet};
 
 /// A set of active trigger outputs. Each entry is (part_id, socket_idx).
@@ -51,6 +52,9 @@ impl TriggerSystem {
         dt: f32,
     ) {
         self.active_triggers.clear();
+
+        // Hoist RNG initialization to avoid repeated thread-local access in the loop
+        let mut rng = rand::rng();
 
         for module in module_manager.modules() {
             for part in &module.parts {
@@ -142,8 +146,6 @@ impl TriggerSystem {
 
                             // Initialize target if needed (first run or after type switch)
                             if state.target < 0.0 {
-                                use rand::Rng;
-                                let mut rng = rand::rng();
                                 state.target = rng.random_range(*min_interval_ms..=*max_interval_ms)
                                     as f32
                                     / 1000.0;
@@ -156,8 +158,6 @@ impl TriggerSystem {
                                 self.active_triggers.insert((part.id, 0));
 
                                 // Pick new target
-                                use rand::Rng;
-                                let mut rng = rand::rng();
                                 state.target = rng.random_range(*min_interval_ms..=*max_interval_ms)
                                     as f32
                                     / 1000.0;


### PR DESCRIPTION
💡 What: Hoisted `let mut rng = rand::rng();` out of the inner loop in `TriggerSystem::update`.
🎯 Why: `rand::rng()` accesses thread-local storage. While cheap, doing it repeatedly inside a hot loop (iterating over all modules and parts) is unnecessary overhead. Hoisting it allows reusing the RNG handle.
📊 Impact: Reduces redundant TLS accesses during trigger updates.
🔬 Measurement: Verified with `cargo test -p mapmap-core`.

---
*PR created automatically by Jules for task [7532016923326347224](https://jules.google.com/task/7532016923326347224) started by @MrLongNight*