### PR TITLE
🎨 UI: Unify panel and widget colors with Cyber Dark theme

### DIFF
--- a/.jules/lina-styleui.md
+++ b/.jules/lina-styleui.md
@@ -55,3 +55,13 @@
     - **List:** `egui::ScrollArea` + `egui::Frame` (zebra) + `ui.horizontal`
     - **Actions:** Right-aligned icon buttons (`delete_button`, `lock_button`, `solo_button`).
 **Action:** Applied this pattern to `MappingPanel` and `AudioPanel`. Also added `lock_button` to `custom.rs` for reuse.
+
+## 2024-05-24 – [Unified Widget Colors]
+**Learning:** Hardcoded RGB values in widgets (like `AudioMeter` and overlays) create subtle visual noise and drift from the core theme.
+- **Insight:** Even "utility" widgets like meters and overlays must strictly adhere to the `crate::theme::colors` palette to maintain the "Cyber Dark" immersion.
+- **Pattern:**
+    - **Utility Backgrounds:** `colors::DARKER_GREY` (for meter backgrounds, overlays).
+    - **Utility Frames:** `colors::LIGHTER_GREY` (frames) + `colors::STROKE_GREY` (strokes).
+    - **Geometry:** `CornerRadius::ZERO` (sharp corners) for all panels and overlays.
+    - **Status Colors:** `colors::MINT_ACCENT` (Good/FPS), `colors::CYAN_ACCENT` (Info/Time), `colors::ERROR_COLOR` (Locked/Error).
+**Action:** Removed hardcoded colors and rounded corners from `AudioMeter`, `StyledPanel`, `lock_button`, and `render_stats_overlay`. Replaced with theme constants and sharp corners.

--- a/crates/mapmap-ui/src/lib.rs
+++ b/crates/mapmap-ui/src/lib.rs
@@ -732,21 +732,21 @@ impl AppUI {
             .interactable(false)
             .show(ctx, |ui| {
                 egui::Frame::default()
-                    .fill(egui::Color32::from_rgba_unmultiplied(20, 20, 30, 220))
-                    .corner_radius(4.0)
-                    .stroke(egui::Stroke::new(1.0, egui::Color32::from_rgb(60, 60, 80)))
+                    .fill(crate::theme::colors::DARKER_GREY.linear_multiply(0.9))
+                    .corner_radius(egui::CornerRadius::ZERO)
+                    .stroke(egui::Stroke::new(1.0, crate::theme::colors::STROKE_GREY))
                     .inner_margin(egui::Margin::symmetric(16, 8))
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
                             ui.label(
                                 egui::RichText::new(format!("FPS: {:.0}", fps))
-                                    .color(egui::Color32::from_rgb(100, 200, 100))
+                                    .color(crate::theme::colors::MINT_ACCENT)
                                     .strong(),
                             );
                             ui.separator();
                             ui.label(
                                 egui::RichText::new(format!("{:.1}ms", frame_time_ms))
-                                    .color(egui::Color32::from_rgb(150, 150, 200)),
+                                    .color(crate::theme::colors::CYAN_ACCENT),
                             );
                         });
                     });

--- a/crates/mapmap-ui/src/widgets/audio_meter.rs
+++ b/crates/mapmap-ui/src/widgets/audio_meter.rs
@@ -73,9 +73,9 @@ impl Widget for AudioMeter {
 
 /// Draws the mounting frame with 4 phillips screws
 fn draw_rack_frame(painter: &egui::Painter, rect: Rect) {
-    let frame_color = Color32::from_rgb(45, 45, 50);
-    let frame_highlight = Color32::from_rgb(65, 65, 70);
-    let frame_shadow = Color32::from_rgb(25, 25, 30);
+    let frame_color = crate::theme::colors::LIGHTER_GREY;
+    let frame_highlight = crate::theme::colors::STROKE_GREY;
+    let frame_shadow = crate::theme::colors::DARK_GREY;
 
     // Main frame
     painter.rect_filled(rect, 0.0, frame_color);
@@ -300,7 +300,7 @@ fn draw_digital_stereo(ui: &mut egui::Ui, rect: Rect, db_left: f32, db_right: f3
     let painter = ui.painter();
 
     // Dark background
-    painter.rect_filled(rect, 0.0, Color32::from_rgb(10, 10, 12));
+    painter.rect_filled(rect, 0.0, crate::theme::colors::DARKER_GREY);
 
     // Layout:
     // Top: L

--- a/crates/mapmap-ui/src/widgets/custom.rs
+++ b/crates/mapmap-ui/src/widgets/custom.rs
@@ -306,7 +306,7 @@ pub fn lock_button(ui: &mut Ui, active: bool) -> Response {
     let mut btn = egui::Button::new("🔒");
     if active {
         // Reddish fill for Locked state
-        btn = btn.fill(Color32::from_rgb(200, 50, 50));
+        btn = btn.fill(colors::ERROR_COLOR);
     }
     ui.add(btn)
 }

--- a/crates/mapmap-ui/src/widgets/panel.rs
+++ b/crates/mapmap-ui/src/widgets/panel.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides a consistent frame and background for UI panels.
 
-use egui::{Color32, Stroke, Style, Ui};
+use egui::{Stroke, Style, Ui};
 
 pub struct StyledPanel {
     title: String,
@@ -17,11 +17,11 @@ impl StyledPanel {
 
     pub fn show<R>(self, ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> R {
         let frame = egui::Frame {
-            fill: Color32::from_rgb(35, 35, 40),
-            corner_radius: egui::CornerRadius::same(4),
+            fill: crate::theme::colors::DARK_GREY,
+            corner_radius: egui::CornerRadius::ZERO,
             inner_margin: egui::Margin::same(8),
             outer_margin: egui::Margin::same(0),
-            stroke: Stroke::new(1.0, Color32::from_gray(60)),
+            stroke: Stroke::new(1.0, crate::theme::colors::STROKE_GREY),
             ..Default::default()
         };
 


### PR DESCRIPTION
This PR updates various UI widgets and panels to strictly adhere to the "Cyber Dark" theme defined in `crates/mapmap-ui/src/core/theme.rs`.

Changes include:
- Removing hardcoded RGB values in `StyledPanel`, `AudioMeter`, `render_stats_overlay`, and `lock_button`.
- Replacing them with `crate::theme::colors` constants.
- Enforcing `CornerRadius::ZERO` (sharp corners) for panels and overlays to match the Cyber aesthetic.
- Updating the `lina-styleui.md` journal with these new patterns.

Verified with `cargo check -p mapmap-ui`.

---
*PR created automatically by Jules for task [4529983325290938325](https://jules.google.com/task/4529983325290938325) started by @MrLongNight*