### PR TITLE
🧪 Guardian: Added MIDI Learn Timeout and Mesh Fallback Tests

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -1,5 +1,10 @@
 # Guardian's Journal 🧪
 
+## 2026-02-08 - MIDI Learn Timeout State
+
+**Erkenntnis:** State machines like `MidiLearnState` rely heavily on timeouts for user experience, but logic checks like `check_timeout` are often assumed correct without verifying the state transition actually happens.
+**Aktion:** Explicitly test state machine transitions involving time using `std::thread::sleep` with short durations in unit tests to guarantee UI states (like "Timed Out") are reachable.
+
 ## 2026-02-08 - Audio Data Sanitization
 
 **Erkenntnis:** Rohe Audio-Buffer enthalten oft NaNs oder Infinities von Treibern oder leeren Streams. Das Propagieren dieser Werte in FFT- oder RMS-Berechnungen vergiftet die gesamte Analyse-Pipeline, was zu NaNs in Uniform Buffern führt, die GPU-Treiber zum Absturz bringen oder schwarze Bildschirme verursachen können.

--- a/crates/mapmap-control/src/midi/midi_learn.rs
+++ b/crates/mapmap-control/src/midi/midi_learn.rs
@@ -313,4 +313,37 @@ mod tests {
             panic!("Should have remaining time");
         }
     }
+
+    #[test]
+    fn test_midi_learn_timeout() {
+        let mut manager = MidiLearnManager::new().with_timeout(1);
+
+        // Start learning
+        manager.start_learning("test_timeout_element");
+        assert!(manager.is_learning());
+        assert!(!manager.has_detection());
+
+        // Initial update (should not time out yet)
+        let timed_out_early = manager.update();
+        assert!(!timed_out_early);
+
+        // Wait for timeout (1.1s > 1.0s)
+        std::thread::sleep(Duration::from_millis(1100));
+
+        // Update to trigger check
+        let timed_out = manager.update();
+        assert!(timed_out, "Should return true when timeout occurs");
+
+        // Verify state transition
+        assert!(!manager.is_learning());
+        if let MidiLearnState::TimedOut { target_element } = manager.state() {
+            assert_eq!(target_element, "test_timeout_element");
+        } else {
+            panic!("State should be TimedOut, got {:?}", manager.state());
+        }
+
+        // Subsequent update should not re-trigger (as state is now TimedOut)
+        let timed_out_again = manager.update();
+        assert!(!timed_out_again);
+    }
 }

--- a/crates/mapmap-core/src/module.rs
+++ b/crates/mapmap-core/src/module.rs
@@ -3548,3 +3548,30 @@ mod test_bezier_surface_new {
         assert!((v_last.y - 1.0).abs() < 0.001);
     }
 }
+
+#[cfg(test)]
+mod mesh_conversion_tests {
+    use super::*;
+
+    #[test]
+    fn test_custom_mesh_fallback() {
+        let custom = MeshType::Custom {
+            path: "ignored".to_string(),
+        };
+        let mesh = custom.to_mesh();
+
+        // Should fallback to Quad (4 vertices)
+        assert_eq!(mesh.vertex_count(), 4);
+        // The resulting runtime mesh should have type Quad
+        use crate::mesh::MeshType as CoreMeshType;
+        assert_eq!(mesh.mesh_type, CoreMeshType::Quad);
+
+        // Verify it is a valid quad (corners 0,0 to 1,1)
+        let tl = mesh.vertices[0].position;
+        let br = mesh.vertices[2].position;
+        assert!((tl.x - 0.0).abs() < 0.001);
+        assert!((tl.y - 0.0).abs() < 0.001);
+        assert!((br.x - 1.0).abs() < 0.001);
+        assert!((br.y - 1.0).abs() < 0.001);
+    }
+}


### PR DESCRIPTION
## 🧪 Test-Verbesserungen

**📊 Was:** 
- `test_midi_learn_timeout` in `crates/mapmap-control/src/midi/midi_learn.rs`
- `test_custom_mesh_fallback` in `crates/mapmap-core/src/module.rs`
- Journal Update in `.jules/guardian.md`

**🎯 Warum:** 
- **MIDI Learn:** Die Timeout-Logik (`check_timeout`) war ungetestet. Da dies eine UX-kritische State-Machine ist, stellt der neue Test sicher, dass der Status nach Ablauf der Zeit korrekt auf `TimedOut` wechselt.
- **Mesh Fallback:** `MeshType::Custom` hat aktuell eine TODO-Implementierung. Der Test stellt sicher, dass das Fallback-Verhalten (Quad) konsistent bleibt und nicht zu Abstürzen führt.

**📈 Abdeckung:** 
- Schließt eine Lücke in der State-Machine-Verifikation von `MidiLearnManager`.
- Verifiziert das Fallback-Verhalten einer kritischen Rendering-Komponente.

### Neue Tests:
- [x] `midi_learn::tests::test_midi_learn_timeout`
- [x] `module::mesh_conversion_tests::test_custom_mesh_fallback`

---
*PR created automatically by Jules for task [9486183325747076717](https://jules.google.com/task/9486183325747076717) started by @MrLongNight*