### PR TITLE
Fix GPU Upload Thread blocking main pipeline

### DIFF
--- a/crates/mapmap-control/src/osc/server.rs
+++ b/crates/mapmap-control/src/osc/server.rs
@@ -171,7 +171,8 @@ mod tests {
         // Give server time to start
         thread::sleep(Duration::from_millis(100));
 
-        let client = OscClient::new(&format!("127.0.0.1:{}", port)).expect("Failed to create client");
+        let client =
+            OscClient::new(&format!("127.0.0.1:{}", port)).expect("Failed to create client");
 
         // Send more packets than the buffer size (MAX_PENDING_PACKETS = 1024)
         // We send 2000 packets quickly to trigger backpressure.
@@ -195,7 +196,8 @@ mod tests {
                 thread::sleep(Duration::from_millis(10));
             }
 
-            if empty_streak > 10 { // 100ms of silence
+            if empty_streak > 10 {
+                // 100ms of silence
                 break;
             }
             if count > 5000 {
@@ -213,14 +215,14 @@ mod tests {
         let mut found_alive = false;
         // Check next few packets for alive message
         for _ in 0..100 {
-             if let Some(rosc::OscPacket::Message(msg)) = server.poll_packet() {
-                 if msg.addr == "/test/alive" {
-                     found_alive = true;
-                     break;
-                 }
-             } else {
-                 break;
-             }
+            if let Some(rosc::OscPacket::Message(msg)) = server.poll_packet() {
+                if msg.addr == "/test/alive" {
+                    found_alive = true;
+                    break;
+                }
+            } else {
+                break;
+            }
         }
         assert!(found_alive, "Server should be responsive after flood");
     }

--- a/crates/mapmap-media/src/decoder.rs
+++ b/crates/mapmap-media/src/decoder.rs
@@ -55,10 +55,9 @@ fn yuv420p_to_rgba(yuv_data: &[u8], width: u32, height: u32) -> Vec<u8> {
 
 /// Video decoder trait
 ///
-/// Note: VideoDecoder does not require Send because FFmpeg's scaler context
-/// is not thread-safe. Decoders should be used on a single thread or wrapped
-/// in appropriate synchronization primitives.
-pub trait VideoDecoder {
+/// Note: VideoDecoder requires Send to support multi-threaded decoding.
+/// Implementations must ensure thread safety (e.g. by using Send wrappers for FFI types).
+pub trait VideoDecoder: Send {
     fn next_frame(&mut self) -> Result<VideoFrame>;
     fn seek(&mut self, timestamp: Duration) -> Result<()>;
     fn duration(&self) -> Duration;
@@ -124,12 +123,25 @@ mod ffmpeg_impl {
         ffi::avcodec_default_get_format(ctx, fmt)
     }
 
+    struct SendContext(ffmpeg::software::scaling::Context);
+    unsafe impl Send for SendContext {}
+    impl std::ops::Deref for SendContext {
+        type Target = ffmpeg::software::scaling::Context;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl std::ops::DerefMut for SendContext {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
     pub struct RealFFmpegDecoder {
         input_ctx: ffmpeg::format::context::Input,
         decoder: ffmpeg::codec::decoder::Video,
-        // NOTE: Scaler is not thread-safe (SwsContext is not Send)
-        // For multi-threading: Move scaler creation to next_frame() or use thread_local!
-        scaler: ffmpeg::software::scaling::Context,
+        // Wrapped in SendContext to allow moving to decode thread
+        scaler: SendContext,
         video_stream_idx: usize,
         time_base: ffmpeg::Rational,
         duration: Duration,
@@ -243,7 +255,8 @@ mod ffmpeg_impl {
                 height,
                 ffmpeg::software::scaling::Flags::BILINEAR,
             )
-            .map_err(|e| MediaError::DecoderError(e.to_string()))?;
+            .map_err(|e| MediaError::DecoderError(e.to_string()))
+            .map(SendContext)?;
 
             info!(
                 "Decoder initialized successfully: {}x{} @ {:.2} fps, duration: {:.2}s, hw_accel: {:?}",

--- a/crates/mapmap-media/src/lib.rs
+++ b/crates/mapmap-media/src/lib.rs
@@ -25,7 +25,7 @@ pub mod sequence;
 // The pipeline module requires VideoDecoder to be Send, but FFmpeg's scaler (SwsContext) is not thread-safe.
 // Solution: Use thread-local scaler - create scaler once in decode thread, avoiding Send requirement.
 // This provides zero overhead and clean separation. See pipeline.rs for implementation details.
-// pub mod pipeline;
+pub mod pipeline;
 
 pub use decoder::{FFmpegDecoder, HwAccelType, PixelFormat, TestPatternDecoder, VideoDecoder};
 #[cfg(feature = "hap")]
@@ -35,11 +35,11 @@ pub use hap_decoder::{decode_hap_frame, HapError, HapFrame, HapTextureType};
 pub use image_decoder::{GifDecoder, StillImageDecoder};
 #[cfg(feature = "libmpv")]
 pub use mpv_decoder::MpvDecoder;
+pub use pipeline::{FramePipeline, FrameScheduler, PipelineConfig, PipelineStats, Priority};
 pub use player::{
     LoopMode, PlaybackCommand, PlaybackState, PlaybackStatus, PlayerError, VideoPlayer,
 };
 pub use sequence::ImageSequenceDecoder;
-// pub use pipeline::{FramePipeline, PipelineConfig, PipelineStats, Priority, FrameScheduler};
 
 /// Media errors
 #[derive(Error, Debug)]

--- a/crates/mapmap-media/src/pipeline.rs
+++ b/crates/mapmap-media/src/pipeline.rs
@@ -21,7 +21,7 @@
 //! - Pre-buffering prevents frame stutters
 //! - Overlapped decode + GPU upload
 
-use crate::{DecodedFrame, MediaError, Result, VideoDecoder, VideoPlayer};
+use crate::VideoPlayer;
 use crossbeam_channel::{bounded, Receiver, Sender};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -76,7 +76,7 @@ impl Default for PipelineConfig {
 /// Frame with metadata for pipeline processing
 #[derive(Clone)]
 pub struct PipelineFrame {
-    pub frame: DecodedFrame,
+    pub frame: mapmap_io::VideoFrame,
     pub sequence: u64,
     pub priority: Priority,
 }
@@ -98,6 +98,12 @@ pub struct FramePipeline {
     // Threads
     decode_thread: Option<JoinHandle<()>>,
     config: PipelineConfig,
+}
+
+impl Default for FramePipeline {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FramePipeline {
@@ -124,11 +130,7 @@ impl FramePipeline {
     }
 
     /// Start the decode thread
-    pub fn start_decode_thread<D: VideoDecoder + 'static>(
-        &mut self,
-        mut decoder: D,
-        mut player: VideoPlayer,
-    ) {
+    pub fn start_decode_thread(&mut self, mut player: VideoPlayer) {
         if self.running.load(Ordering::Relaxed) {
             warn!("Decode thread already running");
             return;
@@ -151,7 +153,7 @@ impl FramePipeline {
                     let start = std::time::Instant::now();
 
                     // Update player and get next frame
-                    if let Some(frame) = player.update(Duration::from_secs_f64(1.0 / decoder.fps()))
+                    if let Some(frame) = player.update(Duration::from_secs_f64(1.0 / player.fps()))
                     {
                         let pipeline_frame = PipelineFrame {
                             frame,
@@ -184,7 +186,7 @@ impl FramePipeline {
 
                     // Throttle to approximately match video FPS
                     let elapsed = start.elapsed();
-                    let frame_duration = Duration::from_secs_f64(1.0 / decoder.fps());
+                    let frame_duration = Duration::from_secs_f64(1.0 / player.fps());
                     if elapsed < frame_duration {
                         std::thread::sleep(frame_duration - elapsed);
                     }
@@ -197,9 +199,13 @@ impl FramePipeline {
         self.decode_thread = Some(thread);
     }
 
-    /// Start the upload thread (requires render backend)
-    /// Note: In Phase 1, this is a placeholder. Full implementation requires wgpu integration.
-    pub fn start_upload_thread(&mut self) {
+    /// Start the upload thread with a custom upload function
+    pub fn start_upload_thread<F>(&mut self, upload_fn: F)
+    where
+        F: Fn(&PipelineFrame) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
+            + Send
+            + 'static,
+    {
         let decode_rx = self.decode_rx.clone();
         let upload_tx = self.upload_tx.clone();
         let running = self.running.clone();
@@ -215,15 +221,18 @@ impl FramePipeline {
                         Ok(pipeline_frame) => {
                             let start = std::time::Instant::now();
 
-                            // TODO: Upload to GPU here (Phase 1 placeholder)
-                            // In real implementation:
-                            // 1. Get staging buffer from pool
-                            // 2. Copy frame data to staging buffer
-                            // 3. Record copy command
-                            // 4. Submit to GPU queue
-                            // 5. Send texture handle to render thread
+                            // Execute the upload function
+                            if let Err(e) = upload_fn(&pipeline_frame) {
+                                error!("Failed to upload frame: {}", e);
+                                // Don't forward failed uploads? Or forward anyway?
+                                // If upload failed, the texture is not ready.
+                                // If we don't forward, the render thread won't know.
+                                // But if we forward, the render thread might try to use an old texture.
+                                // Let's continue and NOT forward.
+                                continue;
+                            }
 
-                            // For now, just forward the frame
+                            // Forward to render thread
                             if upload_tx.send(pipeline_frame).is_ok() {
                                 let mut stats = stats.write();
                                 stats.uploaded_frames += 1;
@@ -328,7 +337,7 @@ impl FrameScheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decoder::{TestPatternDecoder, VideoDecoder};
+    use crate::decoder::TestPatternDecoder;
     use crate::player::VideoPlayer;
 
     #[test]
@@ -343,24 +352,32 @@ mod tests {
         let mut scheduler = FrameScheduler::new(3);
 
         let frame1 = PipelineFrame {
-            frame: DecodedFrame {
-                data: vec![],
-                format: crate::decoder::PixelFormat::RGBA8,
-                width: 100,
-                height: 100,
-                pts: Duration::ZERO,
+            frame: mapmap_io::VideoFrame {
+                data: mapmap_io::format::FrameData::Cpu(vec![]),
+                format: mapmap_io::VideoFormat {
+                    width: 100,
+                    height: 100,
+                    pixel_format: mapmap_io::PixelFormat::RGBA8,
+                    frame_rate: 60.0,
+                },
+                timestamp: Duration::ZERO,
+                metadata: mapmap_io::FrameMetadata::default(),
             },
             sequence: 1,
             priority: Priority::Low,
         };
 
         let frame2 = PipelineFrame {
-            frame: DecodedFrame {
-                data: vec![],
-                format: crate::decoder::PixelFormat::RGBA8,
-                width: 100,
-                height: 100,
-                pts: Duration::ZERO,
+            frame: mapmap_io::VideoFrame {
+                data: mapmap_io::format::FrameData::Cpu(vec![]),
+                format: mapmap_io::VideoFormat {
+                    width: 100,
+                    height: 100,
+                    pixel_format: mapmap_io::PixelFormat::RGBA8,
+                    frame_rate: 60.0,
+                },
+                timestamp: Duration::ZERO,
+                metadata: mapmap_io::FrameMetadata::default(),
             },
             sequence: 2,
             priority: Priority::High,
@@ -391,13 +408,12 @@ mod tests {
         let mut pipeline = FramePipeline::new();
         let decoder = TestPatternDecoder::new(640, 480, Duration::from_secs(1), 30.0);
         let mut player = VideoPlayer::new(decoder);
-        player.set_looping(true);
-        player.play();
+        let _ = player.set_loop_mode(crate::player::LoopMode::Loop);
+        let _ = player.play();
 
         // Start decode thread
-        let test_decoder = TestPatternDecoder::new(640, 480, Duration::from_secs(1), 30.0);
-        pipeline.start_decode_thread(test_decoder, player);
-        pipeline.start_upload_thread();
+        pipeline.start_decode_thread(player);
+        pipeline.start_upload_thread(|_| Ok(()));
 
         // Let it run for a bit
         std::thread::sleep(Duration::from_millis(200));

--- a/crates/mapmap/src/app/core/app_struct.rs
+++ b/crates/mapmap/src/app/core/app_struct.rs
@@ -16,7 +16,7 @@ use mapmap_core::{
     AppState, History, ModuleEvaluator, RenderOp,
 };
 use mapmap_mcp::McpAction;
-use mapmap_media::player::VideoPlayer;
+// use mapmap_media::player::VideoPlayer;
 use mapmap_render::{
     ColorCalibrationRenderer, Compositor, EdgeBlendRenderer, EffectChainRenderer, MeshBufferCache,
     MeshRenderer, OscillatorRenderer, QuadRenderer, TexturePool, WgpuBackend,
@@ -100,7 +100,8 @@ pub struct App {
     /// Global frame counter for throttling
     pub frame_counter: u64,
     /// Active media pipelines for source nodes ((ModuleID, PartID) -> Pipeline)
-    pub media_players: HashMap<(ModulePartId, ModulePartId), (String, VideoPlayer)>,
+    pub media_players:
+        HashMap<(ModulePartId, ModulePartId), crate::orchestration::media::MediaPlayerHandle>,
     /// FPS calculation: accumulated frame times
     pub fps_samples: VecDeque<f32>,
     /// Current calculated FPS

--- a/crates/mapmap/src/main.rs
+++ b/crates/mapmap/src/main.rs
@@ -203,11 +203,15 @@ impl App {
                             {
                                 info!("Found media path: '{}' in module '{}'", path, module.name);
                                 if !path.is_empty() {
-                                    match mapmap_media::open_path(path) {
-                                        Ok(player) => {
+                                    let tex_name = format!("part_{}_{}", mod_id, part_id);
+                                    let pool = self.texture_pool.clone();
+                                    let queue = self.backend.queue.clone();
+                                    match crate::orchestration::media::create_player_handle(
+                                        pool, queue, path, &tex_name,
+                                    ) {
+                                        Ok(handle) => {
                                             info!("Successfully created player for '{}'", path);
-                                            self.media_players
-                                                .insert(player_key, (path.clone(), player));
+                                            self.media_players.insert(player_key, handle);
                                         }
                                         Err(e) => {
                                             error!("Failed to load media '{}': {}", path, e);
@@ -219,16 +223,16 @@ impl App {
                     }
                 }
 
-                if let Some((_, player)) = self.media_players.get_mut(&player_key) {
+                if let Some(player) = self.media_players.get_mut(&player_key) {
                     match cmd {
                         MediaPlaybackCommand::Play => {
-                            let _ = player.command_sender().send(PlaybackCommand::Play);
+                            let _ = player.command_tx.send(PlaybackCommand::Play);
                         }
                         MediaPlaybackCommand::Pause => {
-                            let _ = player.command_sender().send(PlaybackCommand::Pause);
+                            let _ = player.command_tx.send(PlaybackCommand::Pause);
                         }
                         MediaPlaybackCommand::Stop => {
-                            let _ = player.command_sender().send(PlaybackCommand::Stop);
+                            let _ = player.command_tx.send(PlaybackCommand::Stop);
                         }
                         MediaPlaybackCommand::Reload => {
                             info!("Reloading media player for part_id={}", part_id);
@@ -236,7 +240,7 @@ impl App {
                         }
                         MediaPlaybackCommand::SetSpeed(speed) => {
                             info!("Setting speed to {} for part_id={}", speed, part_id);
-                            let _ = handle_media_speed(player, speed);
+                            let _ = player.command_tx.send(PlaybackCommand::SetSpeed(speed));
                         }
                         MediaPlaybackCommand::SetLoop(enabled) => {
                             info!("Setting loop to {} for part_id={}", enabled, part_id);
@@ -245,13 +249,11 @@ impl App {
                             } else {
                                 mapmap_media::LoopMode::PlayOnce
                             };
-                            let _ = player
-                                .command_sender()
-                                .send(PlaybackCommand::SetLoopMode(mode));
+                            let _ = player.command_tx.send(PlaybackCommand::SetLoopMode(mode));
                         }
                         MediaPlaybackCommand::Seek(position) => {
                             info!("Seeking to {} for part_id={}", position, part_id);
-                            let _ = player.command_sender().send(PlaybackCommand::Seek(
+                            let _ = player.command_tx.send(PlaybackCommand::Seek(
                                 std::time::Duration::from_secs_f64(position),
                             ));
                         }
@@ -280,14 +282,17 @@ impl App {
                             ) = &part.part_type
                             {
                                 if !path.is_empty() {
-                                    match mapmap_media::open_path(path) {
-                                        Ok(player) => {
+                                    let tex_name = format!("part_{}_{}", mod_id, part_id);
+                                    let pool = self.texture_pool.clone();
+                                    let queue = self.backend.queue.clone();
+                                    match crate::orchestration::media::create_player_handle(
+                                        pool, queue, path, &tex_name,
+                                    ) {
+                                        Ok(handle) => {
                                             info!("Recreated player for '{}' after reload", path);
                                             // Auto-play after reload
-                                            let _ =
-                                                player.command_sender().send(PlaybackCommand::Play);
-                                            self.media_players
-                                                .insert(player_key, (path.clone(), player));
+                                            let _ = handle.command_tx.send(PlaybackCommand::Play);
+                                            self.media_players.insert(player_key, handle);
                                         }
                                         Err(e) => {
                                             error!("Failed to reload media '{}': {}", path, e);
@@ -303,13 +308,6 @@ impl App {
 
         Ok(())
     }
-}
-
-fn handle_media_speed(player: &mut mapmap_media::player::VideoPlayer, speed: f32) -> Result<()> {
-    player
-        .command_sender()
-        .send(PlaybackCommand::SetSpeed(speed))
-        .map_err(|e| anyhow::anyhow!("Failed to send speed command: {}", e))
 }
 
 fn main() -> Result<()> {

--- a/crates/mapmap/src/orchestration/media.rs
+++ b/crates/mapmap/src/orchestration/media.rs
@@ -1,8 +1,88 @@
 //! Video player and media orchestration.
 
 use crate::app::core::app_struct::App;
+use crossbeam_channel::{Receiver, Sender};
 use mapmap_core::module::{ModulePartType, SourceType};
+use mapmap_media::{FramePipeline, PlaybackCommand, PlaybackState, PlaybackStatus};
+use std::time::Duration;
 use tracing::{error, info};
+
+/// Handle for a media player running in a separate thread
+pub struct MediaPlayerHandle {
+    /// Path to the media file
+    pub path: String,
+    /// The frame pipeline handling decoding and uploading
+    pub pipeline: FramePipeline,
+    /// Channel for sending playback commands
+    pub command_tx: Sender<PlaybackCommand>,
+    /// Channel for receiving status updates
+    pub status_rx: Receiver<PlaybackStatus>,
+    /// Current playback time (cached from frames)
+    pub current_time: Duration,
+    /// Total duration of the media
+    pub duration: Duration,
+    /// Current playback state
+    pub state: PlaybackState,
+}
+
+/// Create a new media player handle, spawning decode and upload threads
+pub fn create_player_handle(
+    pool: std::sync::Arc<mapmap_render::TexturePool>,
+    queue: std::sync::Arc<wgpu::Queue>,
+    path: &str,
+    tex_name: &str,
+) -> anyhow::Result<MediaPlayerHandle> {
+    let mut player = mapmap_media::open_path(path)?;
+    let duration = player.duration();
+    let (width, height) = player.resolution();
+
+    // Start playing immediately
+    player.play().map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let command_tx = player.command_sender();
+    let status_rx = player.status_receiver();
+    let state = player.state().clone();
+
+    let mut pipeline = FramePipeline::new();
+
+    // Start decode thread (consumes player)
+    pipeline.start_decode_thread(player);
+
+    let tex_name_owned = tex_name.to_string();
+    let pool_clone = pool.clone();
+
+    // Ensure texture exists initially
+    pool.ensure_texture(
+        &tex_name_owned,
+        if width > 0 { width } else { 1280 },
+        if height > 0 { height } else { 720 },
+        wgpu::TextureFormat::Rgba8UnormSrgb,
+        wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+    );
+
+    pipeline.start_upload_thread(move |frame: &mapmap_media::pipeline::PipelineFrame| {
+        if let mapmap_io::format::FrameData::Cpu(data) = &frame.frame.data {
+            pool_clone.upload_data(
+                &queue,
+                &tex_name_owned,
+                data,
+                frame.frame.format.width,
+                frame.frame.format.height,
+            );
+        }
+        Ok(())
+    });
+
+    Ok(MediaPlayerHandle {
+        path: path.to_string(),
+        pipeline,
+        command_tx,
+        status_rx,
+        current_time: Duration::ZERO,
+        duration,
+        state,
+    })
+}
 
 /// Synchronize media players with active source modules
 pub fn sync_media_players(app: &mut App) {
@@ -32,23 +112,26 @@ pub fn sync_media_players(app: &mut App) {
                     if !path.is_empty() {
                         let key = (module.id, part.id);
                         active_sources.insert(key);
+                        let tex_name = format!("part_{}_{}", module.id, part.id);
+
+                        let pool = app.texture_pool.clone();
+                        let queue = app.backend.queue.clone();
 
                         // Create player if not exists
                         match app.media_players.entry(key) {
                             std::collections::hash_map::Entry::Vacant(e) => {
-                                match mapmap_media::open_path(&path) {
-                                    Ok(mut player) => {
+                                match create_player_handle(
+                                    pool.clone(),
+                                    queue.clone(),
+                                    &path,
+                                    &tex_name,
+                                ) {
+                                    Ok(handle) => {
                                         info!(
                                             "Created media player for module={} part={} path='{}'",
                                             module.id, part.id, path
                                         );
-                                        if let Err(e) = player.play() {
-                                            error!(
-                                                "Failed to start playback for source {}:{} : {}",
-                                                module.id, part.id, e
-                                            );
-                                        }
-                                        e.insert((path.clone(), player));
+                                        e.insert(handle);
                                     }
                                     Err(e) => {
                                         error!(
@@ -60,20 +143,16 @@ pub fn sync_media_players(app: &mut App) {
                             }
                             std::collections::hash_map::Entry::Occupied(mut e) => {
                                 // Check if path changed
-                                let (current_path, player) = e.get_mut();
-                                if *current_path != path {
+                                let handle = e.get_mut();
+                                if handle.path != path {
                                     info!(
                                         "Path changed for source {}:{} -> loading {}",
                                         module.id, part.id, path
                                     );
                                     // Load new media
-                                    match mapmap_media::open_path(&path) {
-                                        Ok(mut new_player) => {
-                                            if let Err(err) = new_player.play() {
-                                                error!("Failed to start playback: {}", err);
-                                            }
-                                            *current_path = path.clone();
-                                            *player = new_player;
+                                    match create_player_handle(pool, queue, &path, &tex_name) {
+                                        Ok(new_handle) => {
+                                            *handle = new_handle;
                                         }
                                         Err(err) => {
                                             error!("Failed to load new media: {}", err);
@@ -95,106 +174,47 @@ pub fn sync_media_players(app: &mut App) {
 
 /// Update all media players and upload frames to texture pool
 #[allow(clippy::manual_is_multiple_of)]
-pub fn update_media_players(app: &mut App, dt: f32) {
-    static FRAME_LOG_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-    let num_frames = FRAME_LOG_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    #[allow(clippy::manual_is_multiple_of)]
-    let log_this_frame = num_frames % 60 == 0;
-
-    let texture_pool = &mut app.texture_pool;
-    let queue = &app.backend.queue;
+pub fn update_media_players(app: &mut App, _dt: f32) {
     let ui_state = &mut app.ui_state;
 
-    for ((mod_id, part_id), (_, player)) in &mut app.media_players {
-        let player: &mut mapmap_media::player::VideoPlayer = player;
-        let tex_name = format!("part_{}_{}", mod_id, part_id);
-
-        // Ensure texture entry exists in pool so we don't hit MAGENTA fallback
-        if !texture_pool.has_texture(&tex_name) {
-            let (width, height) = player.resolution();
-            let (w, h) = if width == 0 || height == 0 {
-                (1280, 720)
-            } else {
-                (width, height)
-            };
-
-            texture_pool.ensure_texture(
-                &tex_name,
-                w,
-                h,
-                wgpu::TextureFormat::Rgba8UnormSrgb,
-                wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-            );
-
-            // Initial black fill
-            let black_data = vec![0u8; (w * h * 4) as usize];
-            texture_pool.upload_data(queue, &tex_name, &black_data, w, h);
-        }
-
-        // Update player logic
-        let update_start = std::time::Instant::now();
-        if let Some(frame) = player.update(std::time::Duration::from_secs_f32(dt)) {
-            let elapsed = update_start.elapsed().as_secs_f64() * 1000.0;
-            if log_this_frame {
-                tracing::debug!(
-                    "Player update took {:.2}ms for {}:{}",
-                    elapsed,
-                    mod_id,
-                    part_id
-                );
-            }
-
-            // Upload to GPU if data is on CPU
-            if let mapmap_io::format::FrameData::Cpu(data) = &frame.data {
-                if log_this_frame {
-                    tracing::info!(
-                        "Frame upload: mod={} part={} size={}x{} pts={:?}",
-                        mod_id,
-                        part_id,
-                        frame.format.width,
-                        frame.format.height,
-                        frame.timestamp
-                    );
+    for ((mod_id, part_id), handle) in &mut app.media_players {
+        // 1. Process Status Updates
+        while let Ok(status) = handle.status_rx.try_recv() {
+            match status {
+                PlaybackStatus::StateChanged(new_state) => {
+                    handle.state = new_state;
                 }
-
-                // CRITICAL: Ensure texture exists in pool with correct format and size
-                texture_pool.ensure_texture(
-                    &tex_name,
-                    frame.format.width,
-                    frame.format.height,
-                    wgpu::TextureFormat::Rgba8UnormSrgb,
-                    wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                );
-
-                let upload_start = std::time::Instant::now();
-                texture_pool.upload_data(
-                    queue,
-                    &tex_name,
-                    data,
-                    frame.format.width,
-                    frame.format.height,
-                );
-                let upload_elapsed = upload_start.elapsed().as_secs_f64() * 1000.0;
-                if log_this_frame {
-                    tracing::debug!(
-                        "Texture upload took {:.2}ms for {}:{}",
-                        upload_elapsed,
-                        mod_id,
-                        part_id
-                    );
+                PlaybackStatus::Looped => {
+                    handle.current_time = Duration::ZERO;
+                }
+                PlaybackStatus::ReachedEnd => {
+                    handle.current_time = handle.duration;
+                    handle.state = PlaybackState::Stopped;
+                }
+                PlaybackStatus::Error(e) => {
+                    error!("Player error {}:{}: {}", mod_id, part_id, e);
+                    handle.state = PlaybackState::Error(e);
                 }
             }
         }
 
-        // Sync player info to UI for timeline display
+        // 2. Process Uploaded Frames (Update timestamp)
+        // Drain the upload queue to get the latest frame info.
+        // Frames are already uploaded to GPU by the upload thread.
+        // We just need the timestamp for UI.
+        while let Ok(frame) = handle.pipeline.upload_rx.try_recv() {
+            handle.current_time = frame.frame.timestamp;
+        }
+
+        // 3. Sync player info to UI
         if let Some(active_id) = ui_state.module_canvas.active_module_id {
             if *mod_id == active_id {
                 ui_state.module_canvas.player_info.insert(
                     *part_id,
                     mapmap_ui::types::MediaPlayerInfo {
-                        current_time: player.current_time().as_secs_f64(),
-                        duration: player.duration().as_secs_f64(),
-                        is_playing: matches!(player.state(), mapmap_media::PlaybackState::Playing),
+                        current_time: handle.current_time.as_secs_f64(),
+                        duration: handle.duration.as_secs_f64(),
+                        is_playing: matches!(handle.state, PlaybackState::Playing),
                     },
                 );
             }


### PR DESCRIPTION
This PR fixes the critical issue where GPU texture uploads were happening on the main thread, causing micro-stutters. 

Key changes:
1.  **Threaded Pipeline**: Fully implemented and enabled `FramePipeline` in `mapmap-media`, which now runs decoding and uploading in separate threads.
2.  **Thread Safety**: Modified `VideoDecoder` (specifically `RealFFmpegDecoder`) to be `Send` by safely wrapping the FFmpeg scaler context, allowing the decoder to be moved to the decode thread.
3.  **App Integration**: Updated `App` struct and `orchestration/media.rs` to use `MediaPlayerHandle`. This handle manages the pipeline threads and communicates via channels, rather than holding the `VideoPlayer` directly.
4.  **Asynchronous Upload**: Implemented the upload logic in `create_player_handle` using a closure passed to the upload thread, which performs `queue.write_texture` off the main thread.
5.  **UI Sync**: `update_media_players` now only consumes status updates and timestamps from the pipeline, ensuring the UI stays in sync without blocking on heavy operations.

This resolves the "GPU Upload Thread blocking the main mapmap-media pipeline" issue tracked in `TECHNICAL_DEBT_AND_BUGS.md`.

---
*PR created automatically by Jules for task [1499173718553143537](https://jules.google.com/task/1499173718553143537) started by @MrLongNight*