### PR TITLE
Fix GPU Upload Blockage by integrating FramePipeline with threaded uploads

### DIFF
--- a/crates/mapmap-media/src/decoder.rs
+++ b/crates/mapmap-media/src/decoder.rs
@@ -55,10 +55,9 @@ fn yuv420p_to_rgba(yuv_data: &[u8], width: u32, height: u32) -> Vec<u8> {
 
 /// Video decoder trait
 ///
-/// Note: VideoDecoder does not require Send because FFmpeg's scaler context
-/// is not thread-safe. Decoders should be used on a single thread or wrapped
-/// in appropriate synchronization primitives.
-pub trait VideoDecoder {
+/// Note: VideoDecoder requires Send to support multi-threaded pipeline.
+/// Implementations must ensure thread safety (e.g. by wrapping non-Send fields).
+pub trait VideoDecoder: Send {
     fn next_frame(&mut self) -> Result<VideoFrame>;
     fn seek(&mut self, timestamp: Duration) -> Result<()>;
     fn duration(&self) -> Duration;
@@ -91,6 +90,13 @@ mod ffmpeg_impl {
     use ffmpeg_next as ffmpeg;
     use ffmpeg_sys_next as ffi;
     use std::path::PathBuf;
+
+    // Wrapper to make scaler Send
+    struct SendScaler(ffmpeg::software::scaling::Context);
+
+    // SAFETY: SwsContext is a pointer. Moving it between threads is safe
+    // as long as we don't access it concurrently. FramePipeline ensures single-threaded access.
+    unsafe impl Send for SendScaler {}
 
     #[cfg(target_os = "windows")]
     unsafe extern "C" fn get_format_callback(
@@ -127,9 +133,9 @@ mod ffmpeg_impl {
     pub struct RealFFmpegDecoder {
         input_ctx: ffmpeg::format::context::Input,
         decoder: ffmpeg::codec::decoder::Video,
-        // NOTE: Scaler is not thread-safe (SwsContext is not Send)
-        // For multi-threading: Move scaler creation to next_frame() or use thread_local!
-        scaler: ffmpeg::software::scaling::Context,
+        // NOTE: Scaler is not thread-safe (SwsContext is not Send).
+        // Wrapped in SendScaler to allow moving to decode thread.
+        scaler: SendScaler,
         video_stream_idx: usize,
         time_base: ffmpeg::Rational,
         duration: Duration,
@@ -257,7 +263,7 @@ mod ffmpeg_impl {
             Ok(Self {
                 input_ctx,
                 decoder,
-                scaler,
+                scaler: SendScaler(scaler),
                 video_stream_idx,
                 time_base,
                 duration,
@@ -364,7 +370,7 @@ mod ffmpeg_impl {
 
                     // Scale to RGBA
                     let mut rgb_frame = ffmpeg::util::frame::Video::empty();
-                    self.scaler
+                    self.scaler.0
                         .run(frame_ptr, &mut rgb_frame)
                         .map_err(|e| MediaError::DecoderError(e.to_string()))?;
 

--- a/crates/mapmap-media/src/lib.rs
+++ b/crates/mapmap-media/src/lib.rs
@@ -25,7 +25,7 @@ pub mod sequence;
 // The pipeline module requires VideoDecoder to be Send, but FFmpeg's scaler (SwsContext) is not thread-safe.
 // Solution: Use thread-local scaler - create scaler once in decode thread, avoiding Send requirement.
 // This provides zero overhead and clean separation. See pipeline.rs for implementation details.
-// pub mod pipeline;
+pub mod pipeline;
 
 pub use decoder::{FFmpegDecoder, HwAccelType, PixelFormat, TestPatternDecoder, VideoDecoder};
 #[cfg(feature = "hap")]
@@ -39,7 +39,10 @@ pub use player::{
     LoopMode, PlaybackCommand, PlaybackState, PlaybackStatus, PlayerError, VideoPlayer,
 };
 pub use sequence::ImageSequenceDecoder;
-// pub use pipeline::{FramePipeline, PipelineConfig, PipelineStats, Priority, FrameScheduler};
+pub use pipeline::{FramePipeline, PipelineConfig, PipelineStats, Priority, FrameScheduler, FrameUploader};
+
+/// Re-export VideoFrame as DecodedFrame for pipeline compatibility
+pub use mapmap_io::VideoFrame as DecodedFrame;
 
 /// Media errors
 #[derive(Error, Debug)]

--- a/crates/mapmap-media/src/pipeline.rs
+++ b/crates/mapmap-media/src/pipeline.rs
@@ -21,13 +21,19 @@
 //! - Pre-buffering prevents frame stutters
 //! - Overlapped decode + GPU upload
 
-use crate::{DecodedFrame, MediaError, Result, VideoDecoder, VideoPlayer};
+use crate::{DecodedFrame, VideoPlayer};
 use crossbeam_channel::{bounded, Receiver, Sender};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
+
+/// Interface for uploading frames to GPU/Texture
+pub trait FrameUploader: Send + Sync {
+    /// Upload a decoded frame to the GPU/Texture pool
+    fn upload(&mut self, frame: &DecodedFrame);
+}
 
 /// Frame pipeline statistics
 #[derive(Debug, Clone, Copy, Default)]
@@ -38,6 +44,7 @@ pub struct PipelineStats {
     pub dropped_frames: u64,
     pub decode_time_ms: f64,
     pub upload_time_ms: f64,
+    pub last_pts_secs: f64,
 }
 
 /// Priority level for pipeline stages
@@ -98,6 +105,9 @@ pub struct FramePipeline {
     // Threads
     decode_thread: Option<JoinHandle<()>>,
     config: PipelineConfig,
+
+    // Optional Uploader
+    uploader: Option<Box<dyn FrameUploader>>,
 }
 
 impl FramePipeline {
@@ -120,15 +130,17 @@ impl FramePipeline {
             stats: Arc::new(parking_lot::RwLock::new(PipelineStats::default())),
             decode_thread: None,
             config,
+            uploader: None,
         }
     }
 
+    /// Set the frame uploader
+    pub fn set_uploader(&mut self, uploader: Box<dyn FrameUploader>) {
+        self.uploader = Some(uploader);
+    }
+
     /// Start the decode thread
-    pub fn start_decode_thread<D: VideoDecoder + 'static>(
-        &mut self,
-        mut decoder: D,
-        mut player: VideoPlayer,
-    ) {
+    pub fn start_decode_thread(&mut self, mut player: VideoPlayer) {
         if self.running.load(Ordering::Relaxed) {
             warn!("Decode thread already running");
             return;
@@ -151,8 +163,9 @@ impl FramePipeline {
                     let start = std::time::Instant::now();
 
                     // Update player and get next frame
-                    if let Some(frame) = player.update(Duration::from_secs_f64(1.0 / decoder.fps()))
-                    {
+                    // Note: player.fps() is used to calculate target frame duration
+                    let target_frame_duration = Duration::from_secs_f64(1.0 / player.fps());
+                    if let Some(frame) = player.update(target_frame_duration) {
                         let pipeline_frame = PipelineFrame {
                             frame,
                             sequence,
@@ -184,9 +197,8 @@ impl FramePipeline {
 
                     // Throttle to approximately match video FPS
                     let elapsed = start.elapsed();
-                    let frame_duration = Duration::from_secs_f64(1.0 / decoder.fps());
-                    if elapsed < frame_duration {
-                        std::thread::sleep(frame_duration - elapsed);
+                    if elapsed < target_frame_duration {
+                        std::thread::sleep(target_frame_duration - elapsed);
                     }
                 }
 
@@ -198,12 +210,12 @@ impl FramePipeline {
     }
 
     /// Start the upload thread (requires render backend)
-    /// Note: In Phase 1, this is a placeholder. Full implementation requires wgpu integration.
     pub fn start_upload_thread(&mut self) {
         let decode_rx = self.decode_rx.clone();
         let upload_tx = self.upload_tx.clone();
         let running = self.running.clone();
         let stats = self.stats.clone();
+        let mut uploader = self.uploader.take();
 
         thread::Builder::new()
             .name("upload-thread".to_string())
@@ -215,19 +227,18 @@ impl FramePipeline {
                         Ok(pipeline_frame) => {
                             let start = std::time::Instant::now();
 
-                            // TODO: Upload to GPU here (Phase 1 placeholder)
-                            // In real implementation:
-                            // 1. Get staging buffer from pool
-                            // 2. Copy frame data to staging buffer
-                            // 3. Record copy command
-                            // 4. Submit to GPU queue
-                            // 5. Send texture handle to render thread
+                            // Upload to GPU if uploader is present
+                            if let Some(uploader) = &mut uploader {
+                                uploader.upload(&pipeline_frame.frame);
+                            }
 
-                            // For now, just forward the frame
-                            if upload_tx.send(pipeline_frame).is_ok() {
+                            // Forward frame metadata (and CPU data if not consumed)
+                            // to main thread for completion/stats
+                            if upload_tx.send(pipeline_frame.clone()).is_ok() {
                                 let mut stats = stats.write();
                                 stats.uploaded_frames += 1;
                                 stats.upload_time_ms = start.elapsed().as_secs_f64() * 1000.0;
+                                stats.last_pts_secs = pipeline_frame.frame.timestamp.as_secs_f64();
                             }
                         }
                         Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
@@ -342,26 +353,21 @@ mod tests {
     fn test_frame_scheduler() {
         let mut scheduler = FrameScheduler::new(3);
 
+        let format = mapmap_io::VideoFormat {
+            width: 100,
+            height: 100,
+            pixel_format: mapmap_io::PixelFormat::RGBA8,
+            frame_rate: 30.0,
+        };
+
         let frame1 = PipelineFrame {
-            frame: DecodedFrame {
-                data: vec![],
-                format: crate::decoder::PixelFormat::RGBA8,
-                width: 100,
-                height: 100,
-                pts: Duration::ZERO,
-            },
+            frame: DecodedFrame::new(vec![], format.clone(), Duration::ZERO),
             sequence: 1,
             priority: Priority::Low,
         };
 
         let frame2 = PipelineFrame {
-            frame: DecodedFrame {
-                data: vec![],
-                format: crate::decoder::PixelFormat::RGBA8,
-                width: 100,
-                height: 100,
-                pts: Duration::ZERO,
-            },
+            frame: DecodedFrame::new(vec![], format, Duration::ZERO),
             sequence: 2,
             priority: Priority::High,
         };
@@ -391,12 +397,11 @@ mod tests {
         let mut pipeline = FramePipeline::new();
         let decoder = TestPatternDecoder::new(640, 480, Duration::from_secs(1), 30.0);
         let mut player = VideoPlayer::new(decoder);
-        player.set_looping(true);
-        player.play();
+        let _ = player.set_loop_mode(crate::player::LoopMode::Loop);
+        let _ = player.play();
 
         // Start decode thread
-        let test_decoder = TestPatternDecoder::new(640, 480, Duration::from_secs(1), 30.0);
-        pipeline.start_decode_thread(test_decoder, player);
+        pipeline.start_decode_thread(player);
         pipeline.start_upload_thread();
 
         // Let it run for a bit

--- a/crates/mapmap/src/app/core/app_struct.rs
+++ b/crates/mapmap/src/app/core/app_struct.rs
@@ -16,7 +16,7 @@ use mapmap_core::{
     AppState, History, ModuleEvaluator, RenderOp,
 };
 use mapmap_mcp::McpAction;
-use mapmap_media::player::VideoPlayer;
+use crate::orchestration::media_pipeline::ActiveMediaPipeline;
 use mapmap_render::{
     ColorCalibrationRenderer, Compositor, EdgeBlendRenderer, EffectChainRenderer, MeshBufferCache,
     MeshRenderer, OscillatorRenderer, QuadRenderer, TexturePool, WgpuBackend,
@@ -100,7 +100,7 @@ pub struct App {
     /// Global frame counter for throttling
     pub frame_counter: u64,
     /// Active media pipelines for source nodes ((ModuleID, PartID) -> Pipeline)
-    pub media_players: HashMap<(ModulePartId, ModulePartId), (String, VideoPlayer)>,
+    pub media_players: HashMap<(ModulePartId, ModulePartId), ActiveMediaPipeline>,
     /// FPS calculation: accumulated frame times
     pub fps_samples: VecDeque<f32>,
     /// Current calculated FPS

--- a/crates/mapmap/src/main.rs
+++ b/crates/mapmap/src/main.rs
@@ -186,49 +186,19 @@ impl App {
             if let Some(mod_id) = target_module_id {
                 let player_key = (mod_id, part_id);
 
-                // If player doesn't exist and we get any command (except Reload), try to create it
-                if !self.media_players.contains_key(&player_key)
-                    && cmd != MediaPlaybackCommand::Reload
-                {
-                    info!(
-                        "Player doesn't exist for part_id={}, attempting to create...",
-                        part_id
-                    );
-                    // Find the source path
-                    if let Some(module) = self.state.module_manager.get_module(mod_id) {
-                        if let Some(part) = module.parts.iter().find(|p| p.id == part_id) {
-                            if let mapmap_core::module::ModulePartType::Source(
-                                mapmap_core::module::SourceType::MediaFile { ref path, .. },
-                            ) = &part.part_type
-                            {
-                                info!("Found media path: '{}' in module '{}'", path, module.name);
-                                if !path.is_empty() {
-                                    match mapmap_media::open_path(path) {
-                                        Ok(player) => {
-                                            info!("Successfully created player for '{}'", path);
-                                            self.media_players
-                                                .insert(player_key, (path.clone(), player));
-                                        }
-                                        Err(e) => {
-                                            error!("Failed to load media '{}': {}", path, e);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                // Note: manual player creation logic removed as sync_media_players handles it every frame.
+                // We just send commands to existing players.
 
-                if let Some((_, player)) = self.media_players.get_mut(&player_key) {
+                if let Some(pipeline) = self.media_players.get_mut(&player_key) {
                     match cmd {
                         MediaPlaybackCommand::Play => {
-                            let _ = player.command_sender().send(PlaybackCommand::Play);
+                            let _ = pipeline.command_tx.send(PlaybackCommand::Play);
                         }
                         MediaPlaybackCommand::Pause => {
-                            let _ = player.command_sender().send(PlaybackCommand::Pause);
+                            let _ = pipeline.command_tx.send(PlaybackCommand::Pause);
                         }
                         MediaPlaybackCommand::Stop => {
-                            let _ = player.command_sender().send(PlaybackCommand::Stop);
+                            let _ = pipeline.command_tx.send(PlaybackCommand::Stop);
                         }
                         MediaPlaybackCommand::Reload => {
                             info!("Reloading media player for part_id={}", part_id);
@@ -236,7 +206,7 @@ impl App {
                         }
                         MediaPlaybackCommand::SetSpeed(speed) => {
                             info!("Setting speed to {} for part_id={}", speed, part_id);
-                            let _ = handle_media_speed(player, speed);
+                            let _ = pipeline.command_tx.send(PlaybackCommand::SetSpeed(speed));
                         }
                         MediaPlaybackCommand::SetLoop(enabled) => {
                             info!("Setting loop to {} for part_id={}", enabled, part_id);
@@ -245,13 +215,11 @@ impl App {
                             } else {
                                 mapmap_media::LoopMode::PlayOnce
                             };
-                            let _ = player
-                                .command_sender()
-                                .send(PlaybackCommand::SetLoopMode(mode));
+                            let _ = pipeline.command_tx.send(PlaybackCommand::SetLoopMode(mode));
                         }
                         MediaPlaybackCommand::Seek(position) => {
                             info!("Seeking to {} for part_id={}", position, part_id);
-                            let _ = player.command_sender().send(PlaybackCommand::Seek(
+                            let _ = pipeline.command_tx.send(PlaybackCommand::Seek(
                                 std::time::Duration::from_secs_f64(position),
                             ));
                         }
@@ -264,7 +232,8 @@ impl App {
                     }
                 }
 
-                // Handle Reload by removing player and immediately recreating
+                // Handle Reload by removing player
+                // sync_media_players will recreate it in the next update cycle
                 if cmd == MediaPlaybackCommand::Reload {
                     if self.media_players.remove(&player_key).is_some() {
                         info!(
@@ -272,44 +241,12 @@ impl App {
                             part_id
                         );
                     }
-                    // Immediately recreate the player
-                    if let Some(module) = self.state.module_manager.get_module(mod_id) {
-                        if let Some(part) = module.parts.iter().find(|p| p.id == part_id) {
-                            if let mapmap_core::module::ModulePartType::Source(
-                                mapmap_core::module::SourceType::MediaFile { ref path, .. },
-                            ) = &part.part_type
-                            {
-                                if !path.is_empty() {
-                                    match mapmap_media::open_path(path) {
-                                        Ok(player) => {
-                                            info!("Recreated player for '{}' after reload", path);
-                                            // Auto-play after reload
-                                            let _ =
-                                                player.command_sender().send(PlaybackCommand::Play);
-                                            self.media_players
-                                                .insert(player_key, (path.clone(), player));
-                                        }
-                                        Err(e) => {
-                                            error!("Failed to reload media '{}': {}", path, e);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
                 }
             }
         }
 
         Ok(())
     }
-}
-
-fn handle_media_speed(player: &mut mapmap_media::player::VideoPlayer, speed: f32) -> Result<()> {
-    player
-        .command_sender()
-        .send(PlaybackCommand::SetSpeed(speed))
-        .map_err(|e| anyhow::anyhow!("Failed to send speed command: {}", e))
 }
 
 fn main() -> Result<()> {

--- a/crates/mapmap/src/orchestration/media.rs
+++ b/crates/mapmap/src/orchestration/media.rs
@@ -1,14 +1,19 @@
 //! Video player and media orchestration.
 
 use crate::app::core::app_struct::App;
+use crate::orchestration::media_pipeline::{ActiveMediaPipeline, WgpuFrameUploader};
 use mapmap_core::module::{ModulePartType, SourceType};
+use mapmap_media::pipeline::FramePipeline;
+use mapmap_media::player::{PlaybackCommand, PlaybackState};
 use tracing::{error, info};
 
 /// Synchronize media players with active source modules
 pub fn sync_media_players(app: &mut App) {
     let mut active_sources = std::collections::HashSet::new();
 
-    // Identify active media files across all source types
+    // Collect active media configurations to avoid borrowing app.state while mutating app.media_players
+    let mut media_configs = Vec::new();
+
     for module in app.state.module_manager.modules() {
         for part in &module.parts {
             if let ModulePartType::Source(source_type) = &part.part_type {
@@ -30,59 +35,82 @@ pub fn sync_media_players(app: &mut App) {
 
                 if let Some(path) = path_result {
                     if !path.is_empty() {
-                        let key = (module.id, part.id);
-                        active_sources.insert(key);
-
-                        // Create player if not exists
-                        match app.media_players.entry(key) {
-                            std::collections::hash_map::Entry::Vacant(e) => {
-                                match mapmap_media::open_path(&path) {
-                                    Ok(mut player) => {
-                                        info!(
-                                            "Created media player for module={} part={} path='{}'",
-                                            module.id, part.id, path
-                                        );
-                                        if let Err(e) = player.play() {
-                                            error!(
-                                                "Failed to start playback for source {}:{} : {}",
-                                                module.id, part.id, e
-                                            );
-                                        }
-                                        e.insert((path.clone(), player));
-                                    }
-                                    Err(e) => {
-                                        error!(
-                                            "Failed to create video player for source {}:{} : {}",
-                                            module.id, part.id, e
-                                        );
-                                    }
-                                }
-                            }
-                            std::collections::hash_map::Entry::Occupied(mut e) => {
-                                // Check if path changed
-                                let (current_path, player) = e.get_mut();
-                                if *current_path != path {
-                                    info!(
-                                        "Path changed for source {}:{} -> loading {}",
-                                        module.id, part.id, path
-                                    );
-                                    // Load new media
-                                    match mapmap_media::open_path(&path) {
-                                        Ok(mut new_player) => {
-                                            if let Err(err) = new_player.play() {
-                                                error!("Failed to start playback: {}", err);
-                                            }
-                                            *current_path = path.clone();
-                                            *player = new_player;
-                                        }
-                                        Err(err) => {
-                                            error!("Failed to load new media: {}", err);
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        media_configs.push((module.id, part.id, path));
                     }
+                }
+            }
+        }
+    }
+
+    for (mod_id, part_id, path) in media_configs {
+        let key = (mod_id, part_id);
+        active_sources.insert(key);
+        let texture_name = format!("part_{}_{}", mod_id, part_id);
+
+        // Check if we need to create or update player
+        let needs_create = if let Some(pipeline) = app.media_players.get(&key) {
+             pipeline.source_path != path
+        } else {
+            true
+        };
+
+        if needs_create {
+            if app.media_players.contains_key(&key) {
+                info!(
+                    "Path changed for source {}:{} -> loading {}",
+                    mod_id, part_id, path
+                );
+                // Remove old player
+                app.media_players.remove(&key);
+            }
+
+            // Create new player
+            match mapmap_media::open_path(&path) {
+                Ok(player) => {
+                    info!(
+                        "Created media player for module={} part={} path='{}'",
+                        mod_id, part_id, path
+                    );
+
+                    // Extract control channels and info before moving player
+                    let command_tx = player.command_sender();
+                    let status_rx = player.status_receiver();
+                    let duration = player.duration();
+
+                    // Initial Play command
+                    let _ = command_tx.send(PlaybackCommand::Play);
+
+                    // Create pipeline
+                    let mut pipeline = FramePipeline::new();
+
+                    // Setup Uploader
+                    let uploader = WgpuFrameUploader::new(
+                        app.backend.queue.clone(),
+                        app.texture_pool.clone(),
+                        texture_name.clone(),
+                    );
+                    pipeline.set_uploader(Box::new(uploader));
+
+                    // Start threads
+                    pipeline.start_decode_thread(player);
+                    pipeline.start_upload_thread();
+
+                    let active_pipeline = ActiveMediaPipeline::new(
+                        pipeline,
+                        command_tx,
+                        status_rx,
+                        texture_name,
+                        duration,
+                        path.clone()
+                    );
+
+                    app.media_players.insert(key, active_pipeline);
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to create video player for source {}:{} : {}",
+                        mod_id, part_id, e
+                    );
                 }
             }
         }
@@ -93,98 +121,17 @@ pub fn sync_media_players(app: &mut App) {
         .retain(|key, _| active_sources.contains(key));
 }
 
-/// Update all media players and upload frames to texture pool
+/// Update all media players and sync stats to UI
 #[allow(clippy::manual_is_multiple_of)]
-pub fn update_media_players(app: &mut App, dt: f32) {
-    static FRAME_LOG_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-    let num_frames = FRAME_LOG_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    #[allow(clippy::manual_is_multiple_of)]
-    let log_this_frame = num_frames % 60 == 0;
-
-    let texture_pool = &mut app.texture_pool;
-    let queue = &app.backend.queue;
+pub fn update_media_players(app: &mut App, _dt: f32) {
     let ui_state = &mut app.ui_state;
 
-    for ((mod_id, part_id), (_, player)) in &mut app.media_players {
-        let player: &mut mapmap_media::player::VideoPlayer = player;
-        let tex_name = format!("part_{}_{}", mod_id, part_id);
+    for ((mod_id, part_id), pipeline) in &mut app.media_players {
+        // Update state from status channel
+        pipeline.update_state();
 
-        // Ensure texture entry exists in pool so we don't hit MAGENTA fallback
-        if !texture_pool.has_texture(&tex_name) {
-            let (width, height) = player.resolution();
-            let (w, h) = if width == 0 || height == 0 {
-                (1280, 720)
-            } else {
-                (width, height)
-            };
-
-            texture_pool.ensure_texture(
-                &tex_name,
-                w,
-                h,
-                wgpu::TextureFormat::Rgba8UnormSrgb,
-                wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-            );
-
-            // Initial black fill
-            let black_data = vec![0u8; (w * h * 4) as usize];
-            texture_pool.upload_data(queue, &tex_name, &black_data, w, h);
-        }
-
-        // Update player logic
-        let update_start = std::time::Instant::now();
-        if let Some(frame) = player.update(std::time::Duration::from_secs_f32(dt)) {
-            let elapsed = update_start.elapsed().as_secs_f64() * 1000.0;
-            if log_this_frame {
-                tracing::debug!(
-                    "Player update took {:.2}ms for {}:{}",
-                    elapsed,
-                    mod_id,
-                    part_id
-                );
-            }
-
-            // Upload to GPU if data is on CPU
-            if let mapmap_io::format::FrameData::Cpu(data) = &frame.data {
-                if log_this_frame {
-                    tracing::info!(
-                        "Frame upload: mod={} part={} size={}x{} pts={:?}",
-                        mod_id,
-                        part_id,
-                        frame.format.width,
-                        frame.format.height,
-                        frame.timestamp
-                    );
-                }
-
-                // CRITICAL: Ensure texture exists in pool with correct format and size
-                texture_pool.ensure_texture(
-                    &tex_name,
-                    frame.format.width,
-                    frame.format.height,
-                    wgpu::TextureFormat::Rgba8UnormSrgb,
-                    wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                );
-
-                let upload_start = std::time::Instant::now();
-                texture_pool.upload_data(
-                    queue,
-                    &tex_name,
-                    data,
-                    frame.format.width,
-                    frame.format.height,
-                );
-                let upload_elapsed = upload_start.elapsed().as_secs_f64() * 1000.0;
-                if log_this_frame {
-                    tracing::debug!(
-                        "Texture upload took {:.2}ms for {}:{}",
-                        upload_elapsed,
-                        mod_id,
-                        part_id
-                    );
-                }
-            }
-        }
+        // Get stats
+        let stats = pipeline.pipeline.stats();
 
         // Sync player info to UI for timeline display
         if let Some(active_id) = ui_state.module_canvas.active_module_id {
@@ -192,9 +139,9 @@ pub fn update_media_players(app: &mut App, dt: f32) {
                 ui_state.module_canvas.player_info.insert(
                     *part_id,
                     mapmap_ui::types::MediaPlayerInfo {
-                        current_time: player.current_time().as_secs_f64(),
-                        duration: player.duration().as_secs_f64(),
-                        is_playing: matches!(player.state(), mapmap_media::PlaybackState::Playing),
+                        current_time: stats.last_pts_secs,
+                        duration: pipeline.duration.as_secs_f64(),
+                        is_playing: matches!(pipeline.current_state, PlaybackState::Playing),
                     },
                 );
             }

--- a/crates/mapmap/src/orchestration/media_pipeline.rs
+++ b/crates/mapmap/src/orchestration/media_pipeline.rs
@@ -1,0 +1,108 @@
+//! Media pipeline integration
+
+use mapmap_media::pipeline::FramePipeline;
+use mapmap_media::pipeline::FrameUploader;
+use mapmap_media::player::{PlaybackCommand, PlaybackState, PlaybackStatus};
+use mapmap_media::DecodedFrame;
+use mapmap_render::TexturePool;
+use std::sync::Arc;
+use crossbeam_channel::{Sender, Receiver};
+
+/// Wrapper for active media pipeline with control channels
+pub struct ActiveMediaPipeline {
+    /// The underlying frame pipeline
+    pub pipeline: FramePipeline,
+    /// Channel to send playback commands
+    pub command_tx: Sender<PlaybackCommand>,
+    /// Channel to receive playback status
+    pub status_rx: Receiver<PlaybackStatus>,
+    /// Name of the texture this pipeline uploads to
+    pub texture_name: String,
+
+    /// Cached duration for UI display
+    pub duration: std::time::Duration,
+    /// Current playback state
+    pub current_state: PlaybackState,
+    /// Path to the source media file
+    pub source_path: String,
+}
+
+impl ActiveMediaPipeline {
+    /// Create a new active media pipeline
+    pub fn new(
+        pipeline: FramePipeline,
+        command_tx: Sender<PlaybackCommand>,
+        status_rx: Receiver<PlaybackStatus>,
+        texture_name: String,
+        duration: std::time::Duration,
+        source_path: String,
+    ) -> Self {
+        Self {
+            pipeline,
+            command_tx,
+            status_rx,
+            texture_name,
+            duration,
+            current_state: PlaybackState::Idle,
+            source_path,
+        }
+    }
+
+    /// Update the internal state by draining status channel
+    pub fn update_state(&mut self) {
+        while let Ok(status) = self.status_rx.try_recv() {
+            match status {
+                PlaybackStatus::StateChanged(state) => self.current_state = state,
+                _ => {}
+            }
+        }
+    }
+}
+
+/// WGPU implementation of FrameUploader
+pub struct WgpuFrameUploader {
+    /// WGPU Queue for texture upload
+    pub queue: Arc<wgpu::Queue>,
+    /// Texture pool for managing textures
+    pub texture_pool: Arc<TexturePool>,
+    /// Name of the target texture
+    pub texture_name: String,
+}
+
+impl WgpuFrameUploader {
+    /// Create a new WGPU frame uploader
+    pub fn new(queue: Arc<wgpu::Queue>, texture_pool: Arc<TexturePool>, texture_name: String) -> Self {
+        Self {
+            queue,
+            texture_pool,
+            texture_name,
+        }
+    }
+}
+
+impl FrameUploader for WgpuFrameUploader {
+    fn upload(&mut self, frame: &DecodedFrame) {
+        let (width, height) = (frame.format.width, frame.format.height);
+
+        // Ensure texture exists and has correct size/format
+        // The pool handles resizing internally if dimensions change
+        self.texture_pool.ensure_texture(
+            &self.texture_name,
+            width,
+            height,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
+            wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        );
+
+        // Upload data if on CPU
+        if let mapmap_io::format::FrameData::Cpu(data) = &frame.data {
+             self.texture_pool.upload_data(
+                &self.queue,
+                &self.texture_name,
+                data,
+                width,
+                height,
+            );
+        }
+    }
+}

--- a/crates/mapmap/src/orchestration/mod.rs
+++ b/crates/mapmap/src/orchestration/mod.rs
@@ -1,5 +1,6 @@
 //! State and Logic orchestration for the application.
 
 pub mod media;
+pub mod media_pipeline;
 pub mod node_logic;
 pub mod outputs;


### PR DESCRIPTION
Integrated `FramePipeline` into `update_media_players`.
Moved video decoding and texture upload logic to background threads.
Implemented `ActiveMediaPipeline` and `WgpuFrameUploader`.
Updated `mapmap-media` to support threaded decoding (`Send` trait for `VideoDecoder` and `SendScaler` wrapper).
Refactored `App` and `media.rs` to use the new pipeline architecture.
This eliminates main thread blocking during media playback.

---
*PR created automatically by Jules for task [2148619995599527479](https://jules.google.com/task/2148619995599527479) started by @MrLongNight*