### PR TITLE
🧪 Guardian: Fix TriggerSystem logic for Fixed/Random triggers

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -107,3 +107,11 @@ Added regression tests `test_resilience_to_bad_input` and `test_resize_mode_zero
 
 **Erkenntnis:** `TriggerSystem` akkumulierte Trigger-Status für gelöschte Parts (Speicherleck) und initialisierte RNG in der Hot-Loop. Außerdem gab es keine Garantie, dass `AudioFFT` Socket-Indizes in `TriggerSystem` mit `module.rs` übereinstimmen.
 **Aktion:** Garbage Collection und RNG-Optimierung in `TriggerSystem::update` implementiert. `test_trigger_system_garbage_collection` und `test_audio_fft_socket_consistency` hinzugefügt, um Lecks und Inkonsistenzen zu verhindern.
+
+## 2026-06-25 - [Trigger Logic Inconsistency]
+
+**Erkenntnis:** `TriggerSystem` und `ModuleEvaluator` implementierten unterschiedliche Logik für `Fixed` und `Random` Trigger.
+`ModuleEvaluator` implementierte `Random` Trigger als statenloses Rauschen (Ignorieren von Intervallen), während `TriggerSystem` Intervalle nutzte, aber `probability` ignorierte.
+Zudem ignorierte `TriggerSystem` den `offset_ms` Parameter für `Fixed` Trigger.
+**Aktion:** `TriggerSystem` wurde korrigiert, um `offset_ms` (als initiale Verzögerung) und `probability` (als Filter bei Intervall-Ende) zu respektieren.
+Die Inkonsistenz im `ModuleEvaluator` bleibt bestehen, da dieser statenlos ist und keine Intervalle korrekt abbilden kann. Dies sollte bei zukünftigen Refactorings adressiert werden.

--- a/crates/mapmap-core/src/trigger_system.rs
+++ b/crates/mapmap-core/src/trigger_system.rs
@@ -129,22 +129,36 @@ impl TriggerSystem {
                                 self.active_triggers.insert((part.id, 0));
                             }
                         }
-                        TriggerType::Fixed { interval_ms, .. } => {
+                        TriggerType::Fixed {
+                            interval_ms,
+                            offset_ms,
+                        } => {
                             active_state_users.insert(part.id); // Mark as using state
 
                             let interval = *interval_ms as f32 / 1000.0;
+                            let offset = *offset_ms as f32 / 1000.0;
+
                             // Unified state lookup (O(1))
                             let state = self.states.entry(part.id).or_default();
+
+                            // Initialize target (used for offset delay on first run)
+                            if state.target < 0.0 {
+                                state.target = offset;
+                            }
+
                             state.timer += dt;
-                            if state.timer >= interval {
-                                state.timer -= interval;
+                            if state.timer >= state.target {
+                                state.timer -= state.target;
                                 self.active_triggers.insert((part.id, 0));
+
+                                // Subsequent targets are just the interval
+                                state.target = interval;
                             }
                         }
                         TriggerType::Random {
                             min_interval_ms,
                             max_interval_ms,
-                            ..
+                            probability,
                         } => {
                             active_state_users.insert(part.id); // Mark as using state
 
@@ -162,7 +176,11 @@ impl TriggerSystem {
 
                             if state.timer >= state.target {
                                 state.timer = 0.0;
-                                self.active_triggers.insert((part.id, 0));
+
+                                // Check probability
+                                if rng.random::<f32>() < *probability {
+                                    self.active_triggers.insert((part.id, 0));
+                                }
 
                                 // Pick new target using hoisted RNG
                                 state.target = rng.random_range(*min_interval_ms..=*max_interval_ms)
@@ -222,11 +240,11 @@ mod tests {
         let mut system = TriggerSystem::new();
         let audio = AudioTriggerData::default();
 
-        // 0.0s -> 0.05s (No trigger)
+        // 0.0s -> 0.05s (Trigger! Because offset=0, it starts immediately)
         system.update(&manager, &audio, 0.05);
-        assert!(!system.is_active(part_id, 0));
+        assert!(system.is_active(part_id, 0));
 
-        // 0.05s -> 0.10s (Trigger!)
+        // 0.05s -> 0.10s (Trigger! 100ms mark reached)
         system.update(&manager, &audio, 0.05);
         assert!(system.is_active(part_id, 0));
 
@@ -406,6 +424,136 @@ mod tests {
         assert!(
             !system.is_active(part_id, expected_sockets.len()),
             "Index out of bounds should not be active"
+        );
+    }
+
+    #[test]
+    fn test_fixed_trigger_offset_logic() {
+        let mut manager = ModuleManager::new();
+        let module_id = manager.create_module("Test Offset".to_string());
+
+        // Interval 100ms, Offset 50ms
+        // Expect triggers at 50ms, 150ms, 250ms...
+        let trigger_type = ModulePartType::Trigger(TriggerType::Fixed {
+            interval_ms: 100,
+            offset_ms: 50,
+        });
+
+        let part_id = manager
+            .add_part_to_module(module_id, PartType::Trigger, (0.0, 0.0))
+            .unwrap();
+
+        if let Some(module) = manager.get_module_mut(module_id) {
+            if let Some(part) = module.parts.iter_mut().find(|p| p.id == part_id) {
+                part.part_type = trigger_type;
+            }
+        }
+
+        let mut system = TriggerSystem::new();
+        let audio = AudioTriggerData::default();
+
+        // 0.0s -> 0.04s (Total 0.04s)
+        // Should NOT fire (target is 50ms)
+        system.update(&manager, &audio, 0.04);
+        assert!(
+            !system.is_active(part_id, 0),
+            "Should not fire before offset (40ms < 50ms)"
+        );
+
+        // 0.04s -> 0.06s (Total 0.06s)
+        // Should FIRE (crossed 50ms)
+        system.update(&manager, &audio, 0.02);
+        assert!(
+            system.is_active(part_id, 0),
+            "Should fire after offset (60ms > 50ms)"
+        );
+
+        // 0.06s -> 0.14s (Total 0.14s)
+        // Next target is +100ms = 150ms. Current time 140ms.
+        // Should NOT fire.
+        system.update(&manager, &audio, 0.08);
+        assert!(
+            !system.is_active(part_id, 0),
+            "Should not fire before interval (140ms < 150ms)"
+        );
+
+        // 0.14s -> 0.16s (Total 0.16s)
+        // Should FIRE (crossed 150ms)
+        system.update(&manager, &audio, 0.02);
+        assert!(
+            system.is_active(part_id, 0),
+            "Should fire after interval (160ms > 150ms)"
+        );
+    }
+
+    #[test]
+    fn test_random_trigger_probability_logic() {
+        let mut manager = ModuleManager::new();
+        let module_id = manager.create_module("Test Probability".to_string());
+
+        // Random Trigger with 0% probability
+        // Interval 10ms (fast)
+        let trigger_type_0 = ModulePartType::Trigger(TriggerType::Random {
+            min_interval_ms: 10,
+            max_interval_ms: 10,
+            probability: 0.0,
+        });
+
+        let part_id = manager
+            .add_part_to_module(module_id, PartType::Trigger, (0.0, 0.0))
+            .unwrap();
+
+        if let Some(module) = manager.get_module_mut(module_id) {
+            if let Some(part) = module.parts.iter_mut().find(|p| p.id == part_id) {
+                part.part_type = trigger_type_0;
+            }
+        }
+
+        let mut system = TriggerSystem::new();
+        let audio = AudioTriggerData::default();
+
+        // Run for 100ms (10 intervals)
+        // Should NEVER fire
+        for _ in 0..10 {
+            system.update(&manager, &audio, 0.011); // 11ms
+            assert!(
+                !system.is_active(part_id, 0),
+                "Probability 0.0 should never fire"
+            );
+        }
+
+        // Change to 100% probability
+        let trigger_type_100 = ModulePartType::Trigger(TriggerType::Random {
+            min_interval_ms: 10,
+            max_interval_ms: 10,
+            probability: 1.0,
+        });
+
+        if let Some(module) = manager.get_module_mut(module_id) {
+            if let Some(part) = module.parts.iter_mut().find(|p| p.id == part_id) {
+                part.part_type = trigger_type_100;
+            }
+        }
+
+        // Need to reset system or wait for next interval
+        // Run for 100ms
+        // Should FIRE every time
+        // Note: Changing part type on the fly might not reset the state immediately in TriggerSystem
+        // because state is persistent by ID.
+        // But the probability is checked at the moment of firing.
+        // So it should start firing.
+
+        let mut fired_count = 0;
+        for _ in 0..10 {
+            system.update(&manager, &audio, 0.011); // 11ms
+            if system.is_active(part_id, 0) {
+                fired_count += 1;
+            }
+        }
+        assert!(
+            fired_count > 0,
+            "Probability 1.0 should fire (fired {} times)",
+            fired_count
         );
     }
 }


### PR DESCRIPTION
## 🧪 Test-Verbesserungen

**📊 Was:** 
- Korrektur der `TriggerType::Fixed` Logik in `TriggerSystem`, um `offset_ms` zu respektieren.
- Korrektur der `TriggerType::Random` Logik in `TriggerSystem`, um `probability` zu respektieren.
- Hinzufügen von Regressionstests für diese Fälle.

**🎯 Warum:** 
- `offset_ms` wurde ignoriert, was zu falschem Timing bei phasenverschobenen Triggern führte.
- `probability` wurde ignoriert, was dazu führte, dass Random Trigger immer feuerten.
- Identifizierte Inkonsistenz zwischen `TriggerSystem` (stateful) und `ModuleEvaluator` (stateless).

**📈 Abdeckung:** 
- `crates/mapmap-core/src/trigger_system.rs` Abdeckung erhöht.

### Neue Tests:
- [x] `test_fixed_trigger_offset_logic`
- [x] `test_random_trigger_probability_logic`

### Geänderte Tests:
- [x] `test_fixed_trigger` - Updated to reflect correct immediate start behavior when offset is 0.

---
*PR created automatically by Jules for task [17975996211275252529](https://jules.google.com/task/17975996211275252529) started by @MrLongNight*