### PR TITLE
UX: Add context menu reset to custom widgets

### DIFF
--- a/crates/mapmap-ui/src/widgets/custom.rs
+++ b/crates/mapmap-ui/src/widgets/custom.rs
@@ -152,16 +152,38 @@ pub fn styled_slider(
         info
     });
 
-    response.on_hover_text("Double-click to reset, Drag to adjust, Arrows to fine tune")
+    response.context_menu(|ui| {
+        if ui.button("Reset to Default").clicked() {
+            *value = default_value;
+            ui.close();
+        }
+    });
+
+    response.on_hover_text(
+        "Double-click to reset, Drag to adjust, Arrows to fine tune, Right-click for options",
+    )
 }
 
 pub fn styled_slider_log(
     ui: &mut Ui,
     value: &mut f32,
     range: std::ops::RangeInclusive<f32>,
-    _default_value: f32,
+    default_value: f32,
 ) -> Response {
-    ui.add(egui::Slider::new(value, range).logarithmic(true))
+    let response = ui.add(egui::Slider::new(value, range).logarithmic(true));
+
+    if response.double_clicked() {
+        *value = default_value;
+    }
+
+    response.context_menu(|ui| {
+        if ui.button("Reset to Default").clicked() {
+            *value = default_value;
+            ui.close();
+        }
+    });
+
+    response.on_hover_text("Double-click to reset, Drag to adjust, Right-click for options")
 }
 
 pub fn styled_drag_value(
@@ -198,7 +220,14 @@ pub fn styled_drag_value(
         );
     }
 
-    response.on_hover_text("Double-click to reset")
+    response.context_menu(|ui| {
+        if ui.button("Reset to Default").clicked() {
+            *value = default_value;
+            ui.close();
+        }
+    });
+
+    response.on_hover_text("Double-click to reset, Right-click for options")
 }
 
 pub fn styled_button(ui: &mut Ui, text: &str, _active: bool) -> Response {


### PR DESCRIPTION
This PR implements a standard "Safe Reset" pattern for custom UI widgets in `mapmap-ui`, addressing the need for safer and more predictable parameter resets during live performance.

Changes:
- **`styled_slider`**: Added a right-click context menu with a "Reset to Default" button. Updated tooltip.
- **`styled_slider_log`**: Added double-click to reset functionality (previously missing), added the "Reset to Default" context menu, and updated the tooltip.
- **`styled_drag_value`**: Added the "Reset to Default" context menu and updated the tooltip.

This aligns with the Mary StyleUX philosophy of making the interface safer and more predictable.

---
*PR created automatically by Jules for task [2079361230037856422](https://jules.google.com/task/2079361230037856422) started by @MrLongNight*