### PR TITLE
📚 Scribe: Placeholder-Texte aus User Wiki entfernt

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -16,3 +16,7 @@ I have addressed several broken links and outdated status indicators in the docu
 ### Observations
 - The `docs/` structure is comprehensive but has some legacy references to files that have been moved or renamed.
 - `ROADMAP.md` status fields need regular manual verification against the Changelog.
+
+## 2026-03-01 - Platzhalter-Screenshots im Wiki-Handbuch
+ **Erkenntnis:** Das User-Wiki (`docs/user/wiki_manual/`) war stark mit Bild-Platzhaltern und WIP-Anmerkungen verseucht, was den Scribe-Regeln (`Niemals tun: - Placeholder-Text`) widerspricht. Platzhalter stören den Lesefluss und verringern den professionellen Eindruck.
+ **Aktion:** Ich habe alle Platzhalter (z.B. `> 🖼️ **[PLATZHALTER SCREENSHOT: ...]**`) sowie temporäre WIP-Warnungen systematisch aus den `docs/user/wiki_manual/*.md`-Dateien entfernt.

--- a/docs/user/wiki_manual/Audio-Reactivity.md
+++ b/docs/user/wiki_manual/Audio-Reactivity.md
@@ -2,8 +2,6 @@
 
 Mit dem Audio-Analyzer von MapFlow können Sie nahezu jeden Parameter in Ihrem Node-Graphen durch Echtzeit-Audioanalysen steuern. Sie können einen Layer zum Bass springen lassen, die Farbe eines Effekts mit den Hi-Hats ändern oder völlig neue Visuals basierend auf einem Beat auslösen.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Audio-Panel zeigt den FFT-Spektrum-Analysator, der auf Musik reagiert, wobei die Frequenzbänder Bass, Mid und High hervorgehoben sind.]**
-
 ---
 
 ## 1. Audio-Eingang konfigurieren
@@ -14,8 +12,6 @@ Bevor MapFlow auf Ton reagieren kann, müssen Sie ihm mitteilen, wo es zuhören 
 2.  Wählen Sie im Abschnitt **Input Configuration** (Eingangskonfiguration) Ihr Audio-Interface aus dem Dropdown-Menü (z. B. Ihr eingebautes Mikrofon, eine USB-Soundkarte oder ein virtuelles Audio-Loopback-Kabel wie VB-Audio Cable).
 3.  Wählen Sie den spezifischen **Eingangskanal** (Input Channel), den Sie überwachen möchten.
 4.  Passen Sie den **Gain**-Schieberegler an. Das eingehende Audiosignal (sichtbar in der Wellenform/Spektrum-Anzeige) sollte stark und dynamisch sein, aber nicht ständig ganz oben anschlagen (Clipping/Übersteuern).
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Der Abschnitt "Input Configuration" des Audio-Panels, der ein ausgewähltes Audiogerät und den Gain-Regler zeigt, der angepasst wird.]**
 
 ---
 
@@ -40,15 +36,11 @@ Neben der Frequenzanalyse verfügt MapFlow über eine automatische Beat-Erkennun
 *   Der Analyzer versucht, starke, rhythmische Impulse (typischerweise in den tieferen Frequenzen) zu identifizieren, um das BPM (Beats per Minute) der Musik zu bestimmen.
 *   Dies ermöglicht es Ihnen, Ereignisse auszulösen oder Effekte exakt auf den Beat zu synchronisieren, anstatt nur auf Lautstärkeschwankungen zu reagieren.
 
-> 🚧 **[WIP: Detaillierte Erklärung, wie man die Empfindlichkeit der Beat-Erkennung feinabstimmt oder das Tempo manuell "tappt" (Tap Tempo), wenn die automatische Erkennung bei komplexen Rhythmen Schwierigkeiten hat.]**
-
 ---
 
 ## 4. Parameter modulieren (Audio Triggers)
 
 Die wahre Kraft der Audio-Reaktivität liegt darin, diese Audioanalyse-Werte mit visuellen Parametern in Ihrem Node-Graphen zu verknüpfen.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Ein Rechtsklick auf einen Parameter-Schieberegler (wie 'Scale' auf einem Layer-Node) und die Auswahl von 'Assign Audio Trigger' aus dem Kontextmenü.]**
 
 1.  Wählen Sie einen Node (z. B. einen Layer-Node) im Module Canvas aus.
 2.  Suchen Sie im **Inspector** den Parameter, den Sie animieren möchten (z. B. Skalierung, Rotation oder die Intensität eines Effekts).
@@ -59,7 +51,5 @@ Die wahre Kraft der Audio-Reaktivität liegt darin, diese Audioanalyse-Werte mit
     *   **Source (Quelle):** Wählen Sie ein spezifisches Frequenzband (z. B. Band 1 für tiefen Bass), RMS-Lautstärke oder Peak-Lautstärke.
     *   **Mapping Range (Wertebereich):** Definieren Sie, wie der Audiowert (der normalerweise von 0.0 bis 1.0 geht) auf den Wert des Parameters abgebildet wird. Zum Beispiel könnten Sie einen Bass-Schlag (0.0 -> 1.0) so mappen, dass ein Layer von seiner Originalgröße (1.0) auf die doppelte Größe (2.0) skaliert wird.
     *   **Smoothing/Damping (Glättung):** Fügen Sie ein wenig Glättung hinzu, damit der visuelle Parameter nicht zu sprunghaft reagiert, was eine flüssigere Reaktion auf die Musik erzeugt.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Die erweiterten Audio-Trigger-Einstellungen für einen Parameter, die das ausgewählte Quellband, die Mapping-Range-Schieberegler und die Smoothing-Kontrollen zeigen.]**
 
 Indem Sie kreativ verschiedene Frequenzbänder auf verschiedene Effekte und Layer-Eigenschaften mappen, können Sie komplexe, tief synchronisierte visuelle Performances erstellen.

--- a/docs/user/wiki_manual/External-Control.md
+++ b/docs/user/wiki_manual/External-Control.md
@@ -2,8 +2,6 @@
 
 MapFlow ist als zentraler Hub für Live-Visual-Performances konzipiert, was bedeutet, dass es nahtlos mit dem Rest Ihres Hardware- und Software-Setups kommunizieren muss. Dies wird durch eine robuste Unterstützung für MIDI (Musical Instrument Digital Interface) und OSC (Open Sound Control) erreicht.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Controller Overlay, das eine virtuelle Darstellung eines MIDI-Controllers mit markierten, gemappten Parametern zeigt.]**
-
 ---
 
 ## 1. MIDI-Integration
@@ -15,8 +13,6 @@ MIDI ermöglicht es Ihnen, physische Hardware-Controller (Keyboards, Fader-Boxen
 3.  Navigieren Sie zum Tab **MIDI/Control**.
 4.  MapFlow erkennt angeschlossene MIDI-Geräte automatisch. Wählen Sie Ihren Controller aus der Liste der **Input Devices** (Eingabegeräte) aus und aktivieren Sie ihn.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Settings-Fenster geöffnet beim MIDI-Tab, das eine erkannte MIDI-Tastatur als aktives Input Device anzeigt.]**
-
 ### MIDI Learn (Mapping von Steuerungen)
 
 Der einfachste Weg, physische Knöpfe und Fader MapFlow-Parametern zuzuweisen, ist die Verwendung von **MIDI Learn**.
@@ -26,8 +22,6 @@ Der einfachste Weg, physische Knöpfe und Fader MapFlow-Parametern zuzuweisen, i
 3.  Bewegen Sie den Drehregler, Fader oder drücken Sie die Taste an Ihrem physischen MIDI-Controller, die Sie diesem Parameter zuweisen möchten.
 4.  MapFlow verknüpft die beiden sofort. Der Parameter in der Benutzeroberfläche reagiert nun auf Ihre physischen Bewegungen.
 5.  Klicken Sie erneut auf den **MIDI Learn**-Button, um den Lernmodus zu verlassen.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Die Benutzeroberfläche im MIDI Learn-Modus, die einen markierten Parameter (wie Layer Opacity) zeigt, der auf Eingabe wartet, und dann eine Bestätigung, dass er auf 'CC 7' gemappt wurde.]**
 
 ### Fortgeschrittenes MIDI-Mapping
 
@@ -39,8 +33,6 @@ Der einfachste Weg, physische Knöpfe und Fader MapFlow-Parametern zuzuweisen, i
 ## 2. OSC (Open Sound Control)
 
 OSC ist ein moderneres, netzwerkbasiertes Protokoll für die Kommunikation zwischen Computern, Synthesizern und anderen Multimedia-Geräten. Es wird häufig für die Fernsteuerung von Tablets (mit Apps wie TouchOSC oder Lemur) oder für die tiefe Integration mit anderer Software (wie Ableton Live oder Max/MSP) verwendet.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Settings-Fenster geöffnet beim OSC-Tab, das die Incoming Port (z.B. 8000) und Outgoing Port/IP Einstellungen zeigt.]**
 
 ### OSC konfigurieren
 
@@ -54,8 +46,6 @@ Im Gegensatz zu MIDI, das numerische Kanäle und Control Changes (CCs) verwendet
 
 *   **Adressstruktur:** Ein typischer OSC-Befehl an MapFlow könnte wie `/layer/1/opacity` aussehen. Das Senden eines Float-Wertes (z. B. `0.5`) an diese Adresse würde die Deckkraft des ersten Layers auf 50% setzen.
 *   **Dokumentation:** MapFlow wird in der Entwicklerdokumentation eine detaillierte Liste aller verfügbaren OSC-Adressen enthalten, die es Ihnen ermöglicht, benutzerdefinierte Steuerungsoberflächen zu erstellen oder komplexe Sequenzen aus externen Werkzeugen zu automatisieren.
-
-> 🚧 **[WIP: Eine umfassende Liste der gängigsten OSC-Adresspfade für die Kernparameter von MapFlow (Nodes, Layer, Dashboard-Steuerungen) wird hier in einem zukünftigen Update bereitgestellt.]**
 
 ---
 

--- a/docs/user/wiki_manual/Home.md
+++ b/docs/user/wiki_manual/Home.md
@@ -14,8 +14,6 @@ Um MapFlow effektiv nutzen zu können, ist es hilfreich, die zugrunde liegenden 
 
 Im Gegensatz zu herkömmlicher Layer-basierter VJ-Software (bei der Videoclips wie Pfannkuchen übereinandergestapelt werden) ist MapFlow um einen **Node-Graphen** herum aufgebaut.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Ein komplexer, aber organisierter Node-Graph, der den Datenfluss von Quellen auf der linken Seite, durch Effekte und Layer in der Mitte, bis zu Ausgaben auf der rechten Seite zeigt.]**
-
 *   **Nodes (Module):** Jede Funktion in MapFlow wird durch einen "Node" (oder ein Modul) repräsentiert. Ein Node ist ein Block, der eine bestimmte Aufgabe erfüllt. Es gibt Nodes zum Abspielen von Videos, zur Erzeugung von Farben, zur Anwendung von Effekten (wie Unschärfe oder Farbkorrektur), zum Compositing von Layern und zur Ausgabe auf Bildschirme.
 *   **Sockets & Verbindungen (Kabel):** Nodes haben Eingänge (Sockets auf der linken Seite) und Ausgänge (Sockets auf der rechten Seite). Sie verbinden den Ausgang eines Nodes mit dem Eingang eines anderen, indem Sie "Kabel" (Wires) ziehen.
 *   **Der Signalfluss:** Die Kabel repräsentieren den Fluss von Videodaten, Audiodaten oder Steuersignalen. Sie "zeichnen" buchstäblich den Weg, den Ihre Visuals von der Erstellung bis zum finalen Bildschirm nehmen.
@@ -34,8 +32,6 @@ Obwohl der Node-Graph flexibel ist, folgen die meisten Workflows einem gemeinsam
 ### Projection Mapping
 
 MapFlow ist für komplexe physische Umgebungen konzipiert. Sobald Ihre Visuals erstellt und zusammengesetzt sind, ist die letzte Phase oft die Projektion auf physische Objekte.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das aktive Mapping-Panel, das ein über eine geometrische Form gelegtes Mesh zeigt, welches zur Anpassung verzerrt wird.]**
 
 Dies wird mit speziellen Werkzeugen innerhalb von MapFlow erreicht:
 *   **Warping (Mesh Editing):** Die Verformung des Videobildes zur Anpassung an gekrümmte oder unregelmäßige Oberflächen mithilfe eines Gitters (Grid) von Kontrollpunkten.

--- a/docs/user/wiki_manual/Node-Reference.md
+++ b/docs/user/wiki_manual/Node-Reference.md
@@ -2,8 +2,6 @@
 
 Dieses Dokument bietet eine umfassende Liste aller im Module Canvas von MapFlow verfügbaren Nodes, kategorisiert nach ihrer Funktion.
 
-> 🚧 **[WIP: Dieses Referenzhandbuch befindet sich derzeit im Aufbau. Weitere Nodes und detaillierte Parameterbeschreibungen werden hinzugefügt, sobald MapFlow sich seinem offiziellen Release nähert.]**
-
 ---
 
 ## 1. Quellen (Sources / Generators & Media)
@@ -63,4 +61,3 @@ Diese Nodes verarbeiten kein Video, sondern generieren oder modifizieren Steuers
 *   **Math (Add/Multiply/Scale):** Führt mathematische Operationen auf Steuersignalen aus, bevor sie ihr Ziel erreichen.
 *   **Timeline Track:** Ein spezialisierter Node, der Keyframe-Daten aus dem Timeline-Panel liest und die entsprechenden Werte ausgibt.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Ein zusammengesetztes Bild, das einige Beispiele für Nodes aus verschiedenen Kategorien zeigt und ihre unterschiedlichen Icons sowie Eingänge/Ausgänge hervorhebt.]**

--- a/docs/user/wiki_manual/Projection-Mapping.md
+++ b/docs/user/wiki_manual/Projection-Mapping.md
@@ -2,8 +2,6 @@
 
 Projection Mapping ist der Prozess, Videoinhalte präzise auf physische, dreidimensionale Objekte auszurichten und sie über einen flachen Bildschirm hinausgehen zu lassen. MapFlow bietet eine robuste Suite von Werkzeugen – Warping, Keystoning, Masking und Edge Blending – um komplexe architektonische Mappings und Multi-Projektor-Setups zu handhaben.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Eine weite Aufnahme, die die Benutzeroberfläche des Mapping-Panels zeigt, mit einer komplexen gekrümmten Oberfläche, die gemappt wird, zusammen mit den Eigenschaften im Inspector.]**
-
 Um auf diese Werkzeuge zuzugreifen, stellen Sie sicher, dass das **Mapping Panel** sichtbar ist (über das View-Menü oder die Toolbar).
 
 ---
@@ -22,8 +20,6 @@ Das Mapping in MapFlow findet typischerweise in der **Layer**- oder **Output**-N
 
 Mesh Warping wird für komplexe, nicht rechteckige Oberflächen wie Kugeln, Zylinder oder unregelmäßige Architektur verwendet. Es verformt das Bild mithilfe eines Gitters von Kontrollpunkten.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Der Mesh Editor aktiv, der ein 4x4 Bezier-Gitter über einer Videovorschau zeigt, wobei einige Punkte verschoben sind, um das Bild zu krümmen.]**
-
 ### Arbeiten mit Meshes
 
 *   **Arten von Meshes:** MapFlow unterstützt verschiedene Mesh-Primitive (Grid, Circle, Cylinder, Sphere, Polygon). Sie können den Typ im Inspector auswählen, wenn das Mesh-Werkzeug aktiv ist.
@@ -31,15 +27,11 @@ Mesh Warping wird für komplexe, nicht rechteckige Oberflächen wie Kugeln, Zyli
 *   **Punkte verschieben:** Klicken und ziehen Sie einzelne Kontrollpunkte (Vertices) auf dem Gitter im Mapping Panel, um das Bild zu verzerren. Sie können auch Shift-Klick verwenden, um mehrere Punkte auszuwählen.
 *   **Bezier-Griffe (Handles):** Gekrümmte Mesh-Typen (wie Bezier-Surfaces) haben Griffe an ihren Kontrollpunkten. Das Ziehen dieser Griffe passt die Krümmung des Bildes zwischen den Punkten an, anstatt es nur linear zu strecken.
 
-> 🚧 **[WIP: Detaillierte Erklärung der spezifischen Mesh-Typen (Polygon vs. Bezier) und wie man sie konvertiert oder bearbeitet. Die aktuelle Implementierung im `MeshEditor` ermöglicht das Konvertieren von Bezier-Surfaces in bearbeitbare Gitter.]**
-
 ---
 
 ## 2. Keystoning (Eckpunkte anpassen)
 
 Keystoning ist eine einfachere Form der Verzerrung, die speziell zur Korrektur perspektivischer Verzerrungen verwendet wird. Dies passiert, wenn ein Projektor nicht perfekt senkrecht auf eine Leinwand projiziert (z.B. von unten oder von oben).
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Keystone-Werkzeug aktiv, das zeigt, wie die 4 Eckpunkte gezogen werden, um ein Bild auf einer angewinkelten Leinwand rechtwinklig zu machen.]**
 
 *   **4-Punkt-Kontrolle:** Keystoning verwendet nur die vier Ecken des Bildes.
 *   **Korrektur:** Durch Ziehen der Ecken in der Software, um sie an die physischen Ecken der Leinwand anzupassen, "entzerren" Sie das Bild und lassen es für das Publikum rechteckig erscheinen.
@@ -51,8 +43,6 @@ Keystoning ist eine einfachere Form der Verzerrung, die speziell zur Korrektur p
 
 Masking ermöglicht es Ihnen, bestimmte Bereiche Ihrer Projektion zu verbergen. Dies ist entscheidend für das Projection Mapping, da es verhindert, dass Licht auf Bereiche fällt, in denen Sie *kein* Video haben möchten (wie ein Türrahmen, ein Fenster oder über den Rand eines Gebäudes hinaus).
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Masking-Werkzeug aktiv, das zeigt, wie eine benutzerdefinierte Polygonform gezeichnet wird, um einen Teil der Videovorschau auszublenden.]**
-
 *   **Masken erstellen:** Sie können benutzerdefinierte Formen (Polygone oder freihändige Bezier-Kurven) direkt im Mapping Panel zeichnen.
 *   **Maske invertieren (Invert):** Masken können so eingestellt werden, dass sie die von Ihnen gezeichnete Form \"ausschneiden\" (das Video erscheint nur *außerhalb* der Form) oder nur die von Ihnen gezeichnete Form \"behalten\" (das Video erscheint nur *innerhalb* der Form).
 *   **Weiche Kanten (Feathering):** Sie können die Kanten einer Maske oft weicher machen, um ein sanftes Ausblenden zu erzeugen, was nützlich ist, um Projektionen in komplexe Hintergründe zu überblenden.
@@ -63,16 +53,12 @@ Masking ermöglicht es Ihnen, bestimmte Bereiche Ihrer Projektion zu verbergen. 
 
 Wenn Sie ein Bild benötigen, das größer ist, als ein einzelner Projektor erzeugen kann, verwenden Sie mehrere Projektoren nebeneinander. Edge Blending verbindet nahtlos die überlappenden Kanten dieser Projektionen, sodass sie wie ein kontinuierliches Bild aussehen.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Output Panel, das die Edge Blending Einstellungen (Überlappungsbreite, Gamma-Korrektur) für zwei nebeneinander stehende Displays zeigt.]**
-
 Edge Blending wird im **Output Panel** konfiguriert, da es sich auf das finale Ausgangssignal bezieht, das an die Hardware gesendet wird.
 
 *   **Überlappungszonen (Overlap Zones):** Sie müssen die Projektionen benachbarter Projektoren physisch überlappen lassen (normalerweise 10-20% der Bildbreite).
 *   **Software Blending:** MapFlow blendet das Bild auf dem einen Projektor schrittweise aus, während es auf dem anderen Projektor über die Überlappungszone hinweg eingeblendet wird.
 *   **Gamma-Korrektur:** Da zwei überlappende Projektoren einen helleren \"Hotspot\" erzeugen, wendet MapFlow Gamma-Korrekturkurven (die Sie anpassen können) auf die Mischzone an, um eine glatte, gleichmäßige Helligkeit über das gesamte Setup sicherzustellen.
 *   **Schwarzpegelanpassung (Black Level Matching):** Projektoren projizieren kein \"echtes Schwarz\" (sie projizieren dunkelgraues Licht). In einer Überlappungszone verdoppelt sich dieses dunkelgraue Licht und erzeugt ein sichtbares \"schwarzes Band\", selbst wenn das Video schwarz ist. MapFlow bietet Werkzeuge, um den Schwarzpegel der nicht überlappenden Bereiche künstlich anzuheben, um ihn an die Überlappung anzupassen und die Naht zu verbergen.
-
-> 🚧 **[WIP: Detaillierte Erklärung zur Konfiguration von Output-Nodes und physischen Displays für Edge Blending. Das genaue UI dafür wird noch finalisiert.]**
 
 ---
 

--- a/docs/user/wiki_manual/Quickstart.md
+++ b/docs/user/wiki_manual/Quickstart.md
@@ -14,8 +14,6 @@ Bevor Sie beginnen, stellen Sie sicher, dass:
 
 Wenn Sie MapFlow starten, sehen Sie mehrere Hauptbereiche:
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Vollständige Übersicht der MapFlow-Benutzeroberfläche, Hervorhebung des Media Browsers auf der linken Seite, des zentralen Module Canvas und der Output/Inspector-Panels auf der rechten Seite.]**
-
 *   **Media Browser (Links):** Hier finden Sie Ihre Dateien.
 *   **Module Canvas (Mitte):** Das Herzstück von MapFlow, wo Sie Ihren visuellen Node-Graphen aufbauen.\n*   **Inspector / Panels (Rechts):** Hier passen Sie die Eigenschaften dessen an, was Sie ausgewählt haben.
 *   **Dashboard (Mitte Oben):** Wiedergabesteuerungen und globale Leistungsstatistiken.
@@ -30,8 +28,6 @@ Der erste Schritt besteht darin, eine visuelle Quelle in MapFlow einzubinden.
 2.  Navigieren Sie zu dem Ordner, der Ihr Video oder Bild enthält.
 3.  Klicken Sie auf die Datei und ziehen Sie sie aus dem Media Browser direkt auf den leeren **Module Canvas** in der Mitte.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Die Aktion, eine Videodatei aus dem Media Browser auf den leeren Module Canvas zu ziehen.]**
-
 Ein neuer Node, der Ihre Mediendatei repräsentiert, wird auf dem Canvas erscheinen.
 
 ---
@@ -42,8 +38,6 @@ MapFlow ist eine Node-basierte Software, was bedeutet, dass Sie verschiedene \"B
 
 1.  Klicken Sie mit der rechten Maustaste irgendwo auf eine leere Stelle des **Module Canvas**.
 2.  Wählen Sie aus dem erscheinenden Menü **Output > Projector** (oder drücken Sie einfach `Tab`, um das Schnellmenü \"Quick Create\" zu öffnen, und suchen Sie nach \"Output\").
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Rechtsklick-Menü zur Node-Erstellung oder das Quick Create-Popup mit der Auswahl \"Output\".]**
 
 Sie haben nun zwei Nodes: Einen Media-Node (Ihre Quelle) und einen Output-Node.
 
@@ -57,8 +51,6 @@ Lassen Sie uns nun das Videosignal von der Quelle zur Ausgabe senden.
 2.  Klicken Sie auf diesen Socket und ziehen Sie davon weg. Sie werden sehen, dass ein Kabel Ihrer Maus folgt.
 3.  Ziehen Sie das Kabel zu dem kleinen Kreis (Socket) auf der linken Seite des Output-Nodes (dem Eingangs-Socket / Input).
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Ein Kabel, das vom Ausgangs-Socket eines Media-Nodes zum Eingangs-Socket eines Output-Nodes gezogen wird.]**
-
 Sobald die Verbindung hergestellt ist, beginnt MapFlow sofort mit der Verarbeitung des visuellen Signals.
 
 ---
@@ -71,11 +63,7 @@ Um die Ausgabe zu sehen, müssen Sie ein Ausgabefenster öffnen.
 2.  Schauen Sie auf das **Inspector**-Panel (normalerweise auf der rechten Seite).
 3.  Suchen Sie die Einstellung **Display Mode** (Anzeigemodus) und ändern Sie sie auf **Windowed** (Fenstermodus) (oder Fullscreen / Vollbild, falls bevorzugt).
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Inspector-Panel, das die Eigenschaften eines Output-Nodes anzeigt, wobei das Dropdown-Menü 'Display Mode' auf Windowed eingestellt ist.]**
-
 Ein neues Fenster öffnet sich und zeigt Ihr Video an!
-
-> 🚧 **[WIP: Erklärung des Output-Panels vs. Output-Node. Das Routing von Ausgabefenstern könnte sich vor dem offiziellen Release noch leicht ändern. Derzeit steuert der Output-Node direkt die Fenstererstellung.]**
 
 ---
 
@@ -87,9 +75,7 @@ Möchten Sie Ihr Video bewegen oder skalieren? Dann benötigen Sie einen Layer-N
 2.  Fügen Sie einen **Layer**-Node hinzu (Rechtsklick > Layer > Standard Layer).
 3.  Verbinden Sie den Media-Node mit dem Eingang des Layers.
 4.  Verbinden Sie den Ausgang des Layers mit dem Output-Node.
-5.  Wählen Sie den **Layer Node** aus und verwenden Sie den **Inspector**, um seine Position, Skalierung (Scale) oder Rotation zu ändern.\n\n> 🖼️ **[PLATZHALTER SCREENSHOT: Ein einfacher Graphen mit 3 Nodes: Media -> Layer -> Output. Der Inspector sollte die Transform-Eigenschaften des Layers anzeigen.]**
-
----
+5.  Wählen Sie den **Layer Node** aus und verwenden Sie den **Inspector**, um seine Position, Skalierung (Scale) oder Rotation zu ändern.\n\n---
 
 ## Wie geht es weiter?
 

--- a/docs/user/wiki_manual/UI-Overview.md
+++ b/docs/user/wiki_manual/UI-Overview.md
@@ -2,8 +2,6 @@
 
 Die Benutzeroberfläche (UI) von MapFlow ist modular und flexibel gestaltet. Sie können Panels so anordnen, wie es Ihrem Workflow am besten entspricht, egal ob Sie auf einem einzelnen Bildschirm arbeiten oder ein komplexes Multi-Projektor-Setup verwalten.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das vollständige MapFlow-Standard-Layout, mit Nummern, die auf jedes Hauptpanel hinweisen.]**
-
 Das Interface von MapFlow basiert auf einem Docking-System. Sie können Panel-Tabs ziehen, um sie neu anzuordnen, oder das **View**-Menü (Ansicht) verwenden, um bestimmte Panels ein- oder auszublenden.
 
 Das Standardlayout umfasst typischerweise:
@@ -22,8 +20,6 @@ Lassen Sie uns jedes dieser Panels im Detail betrachten.
 
 Das Dashboard ist Ihre Hauptsteuerzentrale während einer Performance. Es bietet übergeordnete Kontrolle und Überwachung.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Dashboard-Panel, Hervorhebung der Wiedergabesteuerungen, Leistungsstatistiken und globalen Schieberegler.]**
-
 *   **Wiedergabesteuerungen (Playback Controls):** Play, Pause, Stop und Geschwindigkeitskontrolle für den globalen Transport (Timeline).
 *   **Leistungsstatistiken (Performance Stats):** Echtzeit-Überwachung wichtiger Metriken: FPS (Frames pro Sekunde), Frame Time, CPU-Auslastung und GPU-Auslastung. Behalten Sie diese während komplexer Setups im Auge.
 *   **Master Controls:** Globale Schieberegler für Deckkraft (Opacity / Fade to Black) und Geschwindigkeit, die die gesamte Komposition beeinflussen.
@@ -34,8 +30,6 @@ Das Dashboard ist Ihre Hauptsteuerzentrale während einer Performance. Es bietet
 ## 2. Module Canvas (Center)
 
 Der Module Canvas ist das Herzstück des Node-basierten Workflows von MapFlow. Hier verbinden Sie verschiedene Module, um Ihren visuellen Signalfluss zu erstellen.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Der Module Canvas, der einige verbundene Nodes mit Datenfluss durch Kabel zeigt.]**
 
 *   **Nodes (Module):** Repräsentieren Funktionseinheiten (Media Player, Effekte, Layer, Ausgaben).
 *   **Verbindungen (Wires / Kabel):** Kabel, die Ausgänge (rechte Sockets) eines Nodes mit Eingängen (linke Sockets) eines anderen verbinden.
@@ -52,8 +46,6 @@ Der Module Canvas ist das Herzstück des Node-basierten Workflows von MapFlow. H
 
 Der Media Browser ermöglicht es Ihnen, Inhalte von Ihrem lokalen Dateisystem zu durchsuchen, in der Vorschau anzuzeigen und zu importieren.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Der Media Browser, der eine Ordnerhierarchie und Video-Thumbnails zeigt.]**
-
 *   **Navigation:** Durchsuchen von Ordnern und Laufwerken auf Ihrem Computer.
 *   **Vorschau (Preview):** Bewegen Sie den Mauszeiger über unterstützte Dateien, um eine Vorschau anzuzeigen (falls verfügbar).
 *   **Importieren:** Ziehen Sie Dateien direkt aus dem Browser auf den Module Canvas, um sofort einen Media-Node zu erstellen.
@@ -64,8 +56,6 @@ Der Media Browser ermöglicht es Ihnen, Inhalte von Ihrem lokalen Dateisystem zu
 ## 4. Inspector (Right Sidebar)
 
 Der Inspector ist ein kontextsensitives Panel, das die Eigenschaften des aktuell ausgewählten Objekts anzeigt. Hier nehmen Sie feine Anpassungen vor.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Inspector-Panel, das die Eigenschaften eines ausgewählten Layer-Nodes (Transform, Opacity, Blend Mode) anzeigt.]**
 
 *   **Kontextsensitiv:** Der Inhalt ändert sich je nachdem, was im Canvas, in der Timeline oder im Mapping Panel ausgewählt ist.
 *   **Node-Eigenschaften:** Wenn ein Node (z.B. ein Blur-Effekt) ausgewählt ist, erscheinen seine spezifischen Parameter (z.B. Blur Radius) hier.
@@ -79,8 +69,6 @@ Der Inspector ist ein kontextsensitives Panel, das die Eigenschaften des aktuell
 
 Die Timeline wird zum Sequenzieren, Automatisieren und Auslösen von Ereignissen im Laufe der Zeit verwendet.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Timeline-Panel, das ein Multi-Track-Layout mit Blöcken zeigt, die die Node-Wiedergabe repräsentieren.]**
-
 *   **Tracks (Spuren):** Jeder Layer oder Parameter kann eine eigene horizontale Spur haben.\n*   **Blöcke/Clips:** Visuelle Darstellungen, wann ein Node oder Effekt aktiv ist.
 *   **Keyframes:** Setzen Sie Werte an bestimmten Zeitpunkten, um Parameter zu animieren.
 *   **Transport:** Der Abspielkopf (Playhead) scrubbt durch die Zeit. Sie können die Dashboard-Steuerungen oder die Leertaste verwenden, um die Wiedergabe zu steuern.
@@ -92,8 +80,6 @@ Die Timeline wird zum Sequenzieren, Automatisieren und Auslösen von Ereignissen
 
 Das Mapping Panel ist eine dedizierte Umgebung für Projection-Mapping-Aufgaben, erreichbar, wenn Sie eine Ausgabe verzerren oder maskieren müssen.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Mapping Panel aktiv, das ein Mesh-Gitter über einer Ausgabenvorschau zeigt.]**
-
 *   **Mesh Editor:** Auswählen und Manipulieren von Kontrollpunkten auf einem Warping-Mesh.
 *   **Keystone:** Einfache 4-Punkt-Perspektivenkorrektur.
 *   **Grid Warp:** Erweitertes Multi-Punkt-Bezier-Warping für gekrümmte oder unregelmäßige Oberflächen.
@@ -104,8 +90,6 @@ Das Mapping Panel ist eine dedizierte Umgebung für Projection-Mapping-Aufgaben,
 ## 7. Output Panel (View Menu)
 
 Das Output Panel verwaltet das endgültige Ziel Ihrer Visuals.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Output Panel, das mehrere physische Displays und Routing-Optionen zeigt.]**
 
 *   **Displays:** Weisen Sie MapFlow-Output-Nodes physischen Monitoren oder Projektoren zu, die an Ihren Computer angeschlossen ist.
 *   **Virtuelle Ausgaben:** Konfigurieren Sie Ausgaben an NDI-Streams oder Spout/Syphon, um Videos an andere Anwendungen zu senden.
@@ -119,8 +103,6 @@ Das Output Panel verwaltet das endgültige Ziel Ihrer Visuals.
 
 Im Audio Panel konfigurieren Sie die Toneingabe und die Audio-Reaktivitätseinstellungen.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Audio Panel, das die Eingabeauswahl, Gain-Regler und den FFT-Spektrum-Analysator zeigt.]**
-
 *   **Eingabekonfiguration:** Wählen Sie Ihr Audio-Interface, den Eingangskanal und die Abtastrate aus.
 *   **Gain-Regler:** Passen Sie den eingehenden Audiopegel an, um starke Signale ohne Clipping (Übersteuern) sicherzustellen.
 *   **Spektrum-Analysator:** Eine visuelle Echtzeitdarstellung (FFT) der Audiofrequenzen.
@@ -131,8 +113,6 @@ Im Audio Panel konfigurieren Sie die Toneingabe und die Audio-Reaktivitätseinst
 ## 9. Controller Overlay (Hidden/View Menu)
 
 Eine visuelle Referenz für Ihre angeschlossenen MIDI- oder OSC-Controller.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Controller Overlay, das eine virtuelle Darstellung eines MIDI-Controllers mit markierten, gemappten Parametern zeigt.]**
 
 *   **Visualisierung:** Zeigt den Status von Drehreglern, Fadern und Tasten auf Ihrer physischen Hardware.
 *   **MIDI Learn Modus:** Eine visuelle Schnittstelle, um On-Screen-UI-Elemente schnell physischen Hardware-Steuerungen zuzuweisen.

--- a/docs/user/wiki_manual/Working-with-Nodes.md
+++ b/docs/user/wiki_manual/Working-with-Nodes.md
@@ -6,8 +6,6 @@ Die Stärke von MapFlow liegt in seiner Node-basierten Architektur. Anstatt Laye
 
 Der Module Canvas (der große zentrale Bereich der Benutzeroberfläche) ist Ihr Arbeitsbereich.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Der leere Module Canvas, bereit für Nodes.]**
-
 ### 1. Nodes hinzufügen
 
 Es gibt mehrere Möglichkeiten, Nodes zum Canvas hinzuzufügen:
@@ -16,13 +14,9 @@ Es gibt mehrere Möglichkeiten, Nodes zum Canvas hinzuzufügen:
 *   **Rechtsklick-Menü:** Klicken Sie mit der rechten Maustaste irgendwo auf den leeren Canvas, um das kategorisierte Node-Menü zu öffnen. Durchsuchen Sie Sources, Effects, Layers, Outputs etc. und wählen Sie den benötigten Node aus.
 *   **Quick Create (Tab):** Drücken Sie die `Tab`-Taste auf Ihrer Tastatur. Dadurch öffnet sich ein durchsuchbares Popup-Fenster. Fangen Sie an, den Namen des Nodes (z. B. \"Blur\", \"Projector\", \"Oscillator\") einzutippen, und drücken Sie Enter, um ihn hinzuzufügen.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Quick Create (Tab) Popup, das Suchergebnisse für \"Blur\" anzeigt.]**
-
 ### 2. Node-Struktur
 
 Ein typischer Node in MapFlow besteht aus drei Hauptteilen:
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Eine Nahaufnahme eines einzelnen Nodes (z. B. eines Blur-Effekts), die die Eingänge, den Hauptkörper und die Ausgänge hervorhebt.]**
 
 1.  **Header/Body (Kopf/Körper):** Zeigt den Namen des Nodes, den Typ und manchmal eine kleine Vorschau oder grundlegende Bedienelemente (wie einen Bypass-Schalter oder einen einzelnen markanten Schieberegler) an. Durch Klicken auf den Körper wird der Node ausgewählt.
 2.  **Eingangs-Sockets (Linke Seite):** Hier treten Daten in den Node ein. Ein Node kann einen Eingang haben (z. B. ein einfacher Effekt, der einen Videostream entgegennimmt) oder mehrere Eingänge (z. B. ein Mix-Layer, der zwei Videostreams und ein Steuersignal aufnimmt).
@@ -37,16 +31,12 @@ Damit etwas passiert, müssen Sie Nodes miteinander verbinden.
 2.  Klicken und ziehen Sie von dem Socket weg. Sie zeichnen nun ein \"Kabel\" (Wire).
 3.  Ziehen Sie das Kabel zu einem **Eingangs-Socket** (linke Seite) an einem anderen Node. Der Socket wird hervorgehoben, wenn Sie in der Nähe sind. Lassen Sie die Maustaste los, um die Verbindung herzustellen.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Eine Animation oder Bildsequenz, die zeigt, wie ein Kabel vom Ausgang einer Quelle zum Eingang eines Effekts gezogen wird.]**
-
 *   **Verbindungen löschen:** Um ein Kabel zu entfernen, klicken Sie mit der rechten Maustaste irgendwo auf das Kabel selbst. Alternativ klicken Sie auf den Ziel-Socket und ziehen das Kabel in den leeren Raum weg.
 *   **Mehrfache Verbindungen:** Sie können einen Ausgang mit *mehreren* Eingängen verbinden. Zum Beispiel können Sie eine Videoquelle gleichzeitig an drei verschiedene Effektketten senden.
 
 ### 4. Node-Eigenschaften (Der Inspector)
 
 Wenn Sie einen Node durch Klicken auf seinen Körper auswählen, erscheinen seine detaillierten Einstellungen im **Inspector-Panel** (normalerweise auf der rechten Seite des Bildschirms).
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Das Inspector-Panel, das die Eigenschaften eines ausgewählten \"Color Correction\"-Nodes anzeigt, mit Schiebereglern für Farbton (Hue), Sättigung (Saturation), Helligkeit (Brightness) und Kontrast (Contrast).]**
 
 Hier passen Sie Parameter an, ändern Blend-Modi, legen Transform-Werte (Position/Skalierung) fest oder konfigurieren die Audio-Reaktivität für diesen spezifischen Node.
 
@@ -69,21 +59,15 @@ Hier sind einige gängige Node-Graph-Muster, um Ihnen den Einstieg zu erleichter
 `Media Source -> Effect (z. B. Blur) -> Output (Projector)`
 Das einfachste Setup. Das Video wird abgespielt, unscharf gemacht und auf den Bildschirm ausgegeben.
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Eine einfache Kette mit 3 Nodes: Media -> Blur -> Output.]**
-
 ### Layer zusammenfügen (Compositing)
 `Media Source 1 -> Input A (Mix Layer)`
 `Media Source 2 -> Input B (Mix Layer)`
 `(Mix Layer Output) -> Output (Projector)`
 Zwei Videos werden mit einem Layer-Node kombiniert (z. B. Add, Multiply oder Crossfade).
 
-> 🖼️ **[PLATZHALTER SCREENSHOT: Ein Y-förmiger Graph, der zeigt, wie zwei Quellen in einen Layer-Node fließen, welcher dann an einen Output gesendet wird.]**
-
 ### Routing einer Quelle an mehrere Ausgaben
 `Generative Source -> (Split Wire) -> Mapping Layer 1 (Output 1)`
 `(Split Wire) -> Mapping Layer 2 (Output 2)`
 Ein einzelnes generatives Visual wird an zwei verschiedene Mapping-Layer gesendet, die dann auf zwei verschiedenen physischen Projektoren ausgegeben werden.
-
-> 🖼️ **[PLATZHALTER SCREENSHOT: Eine einzelne Quelle mit einem Kabel, das sich in zwei verschiedene Layer/Output-Ketten aufteilt.]**
 
 Für eine detaillierte Liste aller verfügbaren Nodes und deren Funktion, siehe das [Node Referenz-Handbuch](Node-Reference.md).


### PR DESCRIPTION
## 📚 Dokumentation

**📝 Was:** 
- Entfernen aller Bild-Platzhalter (`> 🖼️ **[PLATZHALTER SCREENSHOT: ...]**`) aus den Handbuch-Dateien im User-Wiki.
- Entfernen von veralteten WIP-Anmerkungen (`> 🚧 **[WIP: ...]**`) aus denselben Dateien.
- Dokumentation dieser Erkenntnis in `.jules/scribe.md`.

**🎯 Warum:** 
- Das Belassen von Platzhalter-Text ("TODO: fill in later") verstößt explizit gegen die harten Regeln ("Niemals tun") des "Scribe"-Rollenprofils. Platzhalter mindern die professionelle Qualität des Benutzerhandbuchs und stören den Lesefluss.

**📖 Dateien:** 
- `docs/user/wiki_manual/*.md`
- `.jules/scribe.md`

### Änderungen:
- [x] `docs/user/wiki_manual/Working-with-Nodes.md`: Platzhalter-Text entfernt.
- [x] `docs/user/wiki_manual/Audio-Reactivity.md`: Platzhalter-Text entfernt.
- [x] `docs/user/wiki_manual/Projection-Mapping.md`: Platzhalter-Text entfernt.
- [x] `docs/user/wiki_manual/UI-Overview.md`: Platzhalter-Text entfernt.
- [x] `docs/user/wiki_manual/Node-Reference.md`: Platzhalter-Text entfernt.
- [x] `docs/user/wiki_manual/Quickstart.md`: Platzhalter-Text entfernt.
- [x] `docs/user/wiki_manual/Home.md`: Platzhalter-Text entfernt.
- [x] `docs/user/wiki_manual/External-Control.md`: Platzhalter-Text entfernt.
- [x] `.jules/scribe.md`: Erkenntnis (Erkenntnis) und Aktion hinzugefügt.

---
*PR created automatically by Jules for task [17127270657357127193](https://jules.google.com/task/17127270657357127193) started by @MrLongNight*