### PR TITLE
Add persistent UI layout profiles with visibility, panel sizes and settings UI

### DIFF
--- a/crates/mapmap-ui/src/core/config.rs
+++ b/crates/mapmap-ui/src/core/config.rs
@@ -8,6 +8,83 @@ use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
+/// Sichtbarkeitseinstellungen für das Hauptlayout.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct LayoutVisibility {
+    #[serde(default = "default_true")]
+    pub show_toolbar: bool,
+    #[serde(default = "default_true")]
+    pub show_left_sidebar: bool,
+    #[serde(default = "default_true")]
+    pub show_inspector: bool,
+    #[serde(default = "default_true")]
+    pub show_timeline: bool,
+    #[serde(default = "default_true")]
+    pub show_media_browser: bool,
+    #[serde(default)]
+    pub show_module_canvas: bool,
+}
+
+impl Default for LayoutVisibility {
+    fn default() -> Self {
+        Self {
+            show_toolbar: true,
+            show_left_sidebar: true,
+            show_inspector: true,
+            show_timeline: true,
+            show_media_browser: true,
+            show_module_canvas: false,
+        }
+    }
+}
+
+/// Größenparameter des Hauptlayouts.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct LayoutPanelSizes {
+    #[serde(default = "default_sidebar_width")]
+    pub left_sidebar_width: f32,
+    #[serde(default = "default_inspector_width")]
+    pub inspector_width: f32,
+    #[serde(default = "default_timeline_height")]
+    pub timeline_height: f32,
+}
+
+impl Default for LayoutPanelSizes {
+    fn default() -> Self {
+        Self {
+            left_sidebar_width: default_sidebar_width(),
+            inspector_width: default_inspector_width(),
+            timeline_height: default_timeline_height(),
+        }
+    }
+}
+
+/// Persistentes Layout-Profil für die Arbeitsoberfläche.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LayoutProfile {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub visibility: LayoutVisibility,
+    #[serde(default)]
+    pub panel_sizes: LayoutPanelSizes,
+    #[serde(default)]
+    pub lock_layout: bool,
+}
+
+impl LayoutProfile {
+    /// Standardprofil, das dem bisherigen Dock-Layout entspricht.
+    pub fn default_profile() -> Self {
+        Self {
+            id: "default".to_string(),
+            name: "Default".to_string(),
+            visibility: LayoutVisibility::default(),
+            panel_sizes: LayoutPanelSizes::default(),
+            lock_layout: false,
+        }
+    }
+}
+
 /// Style for the audio meter
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum AudioMeterStyle {
@@ -237,6 +314,13 @@ pub struct UserConfig {
     /// Toolbar telemetry visibility and disclosure settings
     #[serde(default)]
     pub toolbar_metrics: ToolbarMetricsConfig,
+
+    /// Verfügbare UI-Layoutprofile
+    #[serde(default = "default_layout_profiles")]
+    pub layouts: Vec<LayoutProfile>,
+    /// Aktives Layoutprofil (id)
+    #[serde(default = "default_active_layout_id")]
+    pub active_layout_id: String,
 }
 
 fn default_true() -> bool {
@@ -245,6 +329,26 @@ fn default_true() -> bool {
 
 fn default_ui_scale() -> f32 {
     1.0
+}
+
+fn default_sidebar_width() -> f32 {
+    300.0
+}
+
+fn default_inspector_width() -> f32 {
+    360.0
+}
+
+fn default_timeline_height() -> f32 {
+    200.0
+}
+
+fn default_layout_profiles() -> Vec<LayoutProfile> {
+    vec![LayoutProfile::default_profile()]
+}
+
+fn default_active_layout_id() -> String {
+    "default".to_string()
 }
 
 impl Default for UserConfig {
@@ -280,6 +384,8 @@ impl Default for UserConfig {
             global_fullscreen: false,
             ui_scale: 1.0,
             toolbar_metrics: ToolbarMetricsConfig::default(),
+            layouts: default_layout_profiles(),
+            active_layout_id: default_active_layout_id(),
         }
     }
 }
@@ -296,7 +402,7 @@ impl UserConfig {
 
     /// Load configuration from disk
     pub fn load() -> Self {
-        Self::config_path()
+        let mut loaded: Self = Self::config_path()
             .and_then(|path| {
                 if path.exists() {
                     fs::read_to_string(&path).ok()
@@ -305,7 +411,10 @@ impl UserConfig {
                 }
             })
             .and_then(|content| serde_json::from_str(&content).ok())
-            .unwrap_or_default()
+            .unwrap_or_default();
+
+        loaded.ensure_layout_profiles();
+        loaded
     }
 
     /// Save configuration to disk
@@ -404,6 +513,51 @@ impl UserConfig {
             .collect();
         (mapflow, streamerbot, mixxx)
     }
+
+    /// Stellt sicher, dass mindestens ein valides Layoutprofil verfügbar ist.
+    pub fn ensure_layout_profiles(&mut self) {
+        if self.layouts.is_empty() {
+            self.layouts = default_layout_profiles();
+        }
+
+        if !self.layouts.iter().any(|l| l.id == self.active_layout_id) {
+            self.active_layout_id = self
+                .layouts
+                .first()
+                .map(|l| l.id.clone())
+                .unwrap_or_else(default_active_layout_id);
+        }
+    }
+
+    /// Liefert das aktive Layoutprofil.
+    pub fn active_layout(&self) -> Option<&LayoutProfile> {
+        self.layouts.iter().find(|l| l.id == self.active_layout_id)
+    }
+
+    /// Liefert das aktive Layoutprofil als mutable Referenz.
+    pub fn active_layout_mut(&mut self) -> Option<&mut LayoutProfile> {
+        self.layouts
+            .iter_mut()
+            .find(|l| l.id == self.active_layout_id)
+    }
+
+    /// Wechselt das aktive Layoutprofil.
+    pub fn set_active_layout(&mut self, layout_id: &str) -> bool {
+        if self.layouts.iter().any(|l| l.id == layout_id) {
+            self.active_layout_id = layout_id.to_string();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Erstellt ein neues Layoutprofil als Kopie der übergebenen Daten.
+    pub fn add_layout_profile(&mut self, mut profile: LayoutProfile) {
+        if profile.id.trim().is_empty() {
+            profile.id = format!("layout-{}", self.layouts.len() + 1);
+        }
+        self.layouts.push(profile);
+    }
 }
 
 #[cfg(test)]
@@ -448,6 +602,8 @@ mod tests {
             global_fullscreen: true,
             ui_scale: 1.2,
             toolbar_metrics: ToolbarMetricsConfig::default(),
+            layouts: default_layout_profiles(),
+            active_layout_id: default_active_layout_id(),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -456,5 +612,35 @@ mod tests {
         assert_eq!(loaded.language, "de");
         assert_eq!(loaded.recent_files.len(), 2);
         assert_eq!(loaded.meter_style, AudioMeterStyle::Digital);
+    }
+
+    #[test]
+    fn test_ensure_layout_profiles_repairs_empty_state() {
+        let mut config = UserConfig {
+            layouts: Vec::new(),
+            active_layout_id: "missing".to_string(),
+            ..UserConfig::default()
+        };
+
+        config.ensure_layout_profiles();
+
+        assert!(!config.layouts.is_empty());
+        assert_eq!(config.active_layout_id, "default");
+    }
+
+    #[test]
+    fn test_set_active_layout() {
+        let mut config = UserConfig::default();
+        config.add_layout_profile(LayoutProfile {
+            id: "live".to_string(),
+            name: "Live".to_string(),
+            visibility: LayoutVisibility::default(),
+            panel_sizes: LayoutPanelSizes::default(),
+            lock_layout: false,
+        });
+
+        assert!(config.set_active_layout("live"));
+        assert_eq!(config.active_layout_id, "live");
+        assert!(!config.set_active_layout("does-not-exist"));
     }
 }

--- a/crates/mapmap-ui/src/lib.rs
+++ b/crates/mapmap-ui/src/lib.rs
@@ -483,19 +483,19 @@ pub struct AppUI {
 impl Default for AppUI {
     fn default() -> Self {
         // Load user config once at initialization
-        let user_config = config::UserConfig::load();
+        let mut user_config = config::UserConfig::load();
+        user_config.ensure_layout_profiles();
+
+        let active_layout = user_config
+            .active_layout()
+            .cloned()
+            .unwrap_or_else(config::LayoutProfile::default_profile);
 
         // Extract values before moving user_config into struct
         let saved_audio_device = user_config.selected_audio_device.clone();
         let saved_recent_files = user_config.recent_files.clone();
         let saved_language = user_config.language.clone();
         let saved_target_fps = user_config.target_fps.unwrap_or(60.0);
-        // Panel visibility settings
-        let saved_show_left_sidebar = user_config.show_left_sidebar;
-        let saved_show_inspector = user_config.show_inspector;
-        let saved_show_timeline = user_config.show_timeline;
-        let saved_show_media_browser = user_config.show_media_browser;
-        let saved_show_module_canvas = user_config.show_module_canvas;
         let saved_show_controller_overlay = user_config.show_controller_overlay;
 
         Self {
@@ -542,26 +542,26 @@ impl Default for AppUI {
             effect_chain_panel: EffectChainPanel::default(),
             cue_panel: CuePanel::default(),
             timeline_panel: TimelineV2::default(),
-            show_timeline: saved_show_timeline, // Load from config
-            show_shader_graph: false,           // Advanced - hide by default
+            show_timeline: active_layout.visibility.show_timeline,
+            show_shader_graph: false, // Advanced - hide by default
             node_editor_panel: NodeEditor::default(),
             transform_panel: TransformPanel::default(),
             shortcut_editor: ShortcutEditor::new(),
-            show_toolbar: true,
+            show_toolbar: active_layout.visibility.show_toolbar,
             icon_manager: None, // Will be initialized with egui context
             icon_demo_panel: icon_demo_panel::IconDemoPanel::default(),
             user_config,
             show_settings: false,
             show_about: false,
-            show_media_browser: saved_show_media_browser, // Load from config
+            show_media_browser: active_layout.visibility.show_media_browser,
             media_browser: MediaBrowser::new(std::env::current_dir().unwrap_or_default()),
             inspector_panel: InspectorPanel::default(),
-            show_inspector: saved_show_inspector, // Load from config
+            show_inspector: active_layout.visibility.show_inspector,
             module_sidebar: ModuleSidebar::default(),
             show_module_sidebar: true, // Show when Module Canvas is active
             module_canvas: ModuleCanvas::default(),
-            show_module_canvas: saved_show_module_canvas, // Load from config
-            show_left_sidebar: saved_show_left_sidebar,   // Load from config
+            show_module_canvas: active_layout.visibility.show_module_canvas,
+            show_left_sidebar: active_layout.visibility.show_left_sidebar,
             current_audio_level: 0.0,
             current_fps: 60.0,
             current_frame_time_ms: 16.67,
@@ -588,6 +588,30 @@ impl Default for AppUI {
 }
 
 impl AppUI {
+    /// Wendet das aktive Layoutprofil auf die Runtime-Sichtbarkeitsflags an.
+    pub fn apply_active_layout(&mut self) {
+        if let Some(layout) = self.user_config.active_layout() {
+            self.show_toolbar = layout.visibility.show_toolbar;
+            self.show_left_sidebar = layout.visibility.show_left_sidebar;
+            self.show_inspector = layout.visibility.show_inspector;
+            self.show_timeline = layout.visibility.show_timeline;
+            self.show_media_browser = layout.visibility.show_media_browser;
+            self.show_module_canvas = layout.visibility.show_module_canvas;
+        }
+    }
+
+    /// Synchronisiert die Runtime-Sichtbarkeiten zurück in das aktive Layoutprofil.
+    pub fn sync_runtime_to_active_layout(&mut self) {
+        if let Some(layout) = self.user_config.active_layout_mut() {
+            layout.visibility.show_toolbar = self.show_toolbar;
+            layout.visibility.show_left_sidebar = self.show_left_sidebar;
+            layout.visibility.show_inspector = self.show_inspector;
+            layout.visibility.show_timeline = self.show_timeline;
+            layout.visibility.show_media_browser = self.show_media_browser;
+            layout.visibility.show_module_canvas = self.show_module_canvas;
+        }
+    }
+
     /// Update responsive styles based on viewport size
     ///
     /// Only updates every 500ms to preserve performance

--- a/crates/mapmap/src/app/actions.rs
+++ b/crates/mapmap/src/app/actions.rs
@@ -14,6 +14,14 @@ use tracing::{error, info};
 pub fn handle_ui_actions(app: &mut App) -> Result<bool> {
     let actions = app.ui_state.take_actions();
     let mut needs_sync = false;
+    let visibility_before = (
+        app.ui_state.show_toolbar,
+        app.ui_state.show_left_sidebar,
+        app.ui_state.show_inspector,
+        app.ui_state.show_timeline,
+        app.ui_state.show_media_browser,
+        app.ui_state.show_module_canvas,
+    );
 
     for action in actions {
         match action {
@@ -99,13 +107,13 @@ pub fn handle_ui_actions(app: &mut App) -> Result<bool> {
                 app.ui_state.show_controller_overlay = !app.ui_state.show_controller_overlay;
             }
             UIAction::ResetLayout => {
-                app.ui_state.show_left_sidebar = true;
-                app.ui_state.show_timeline = true;
-                app.ui_state.show_inspector = true;
-                app.ui_state.show_media_browser = true;
-                app.ui_state.show_module_canvas = false;
+                let active_layout_id = app.ui_state.user_config.active_layout_id.clone();
+                if let Some(layout) = app.ui_state.user_config.active_layout_mut() {
+                    *layout = mapmap_ui::core::config::LayoutProfile::default_profile();
+                    layout.id = active_layout_id;
+                }
+                app.ui_state.apply_active_layout();
                 app.ui_state.show_stats = true;
-                app.ui_state.show_toolbar = true;
                 app.ui_state.show_master_controls = true;
             }
             UIAction::Play => {
@@ -658,6 +666,20 @@ pub fn handle_ui_actions(app: &mut App) -> Result<bool> {
     // Also process implicit MCP actions that were sent via UI actions?
     // The loop above already handles UI -> MCP Sender calls, and handle_mcp_actions pulls from Receiver.
     // So this is correct.
+
+    let visibility_after = (
+        app.ui_state.show_toolbar,
+        app.ui_state.show_left_sidebar,
+        app.ui_state.show_inspector,
+        app.ui_state.show_timeline,
+        app.ui_state.show_media_browser,
+        app.ui_state.show_module_canvas,
+    );
+
+    if visibility_before != visibility_after {
+        app.ui_state.sync_runtime_to_active_layout();
+        let _ = app.ui_state.user_config.save();
+    }
 
     Ok(needs_sync)
 }

--- a/crates/mapmap/src/app/ui_layout.rs
+++ b/crates/mapmap/src/app/ui_layout.rs
@@ -10,8 +10,22 @@ pub fn show(ctx: &egui::Context, app: &mut App) {
     let viewport_width = viewport_rect.width();
     let viewport_height = viewport_rect.height();
     let compact_height = viewport_height < 760.0;
-    let sidebar_default = (viewport_width * 0.22).clamp(220.0, 420.0);
-    let inspector_default = (viewport_width * 0.24).clamp(260.0, 520.0);
+    let active_layout = app.ui_state.user_config.active_layout().cloned();
+    let layout_sizes = active_layout
+        .as_ref()
+        .map(|layout| layout.panel_sizes)
+        .unwrap_or_default();
+    let layout_locked = active_layout
+        .as_ref()
+        .map(|layout| layout.lock_layout)
+        .unwrap_or(false);
+    let sidebar_default = layout_sizes
+        .left_sidebar_width
+        .clamp(220.0, (viewport_width * 0.45).max(340.0));
+    let inspector_default = layout_sizes
+        .inspector_width
+        .clamp(260.0, (viewport_width * 0.5).max(420.0));
+    let timeline_default = layout_sizes.timeline_height.clamp(100.0, 500.0);
 
     // 1. Global Menu Bar (Top-most)
     let menu_actions = ui::view::menu_bar::show(ctx, &mut app.ui_state);
@@ -22,7 +36,7 @@ pub fn show(ctx: &egui::Context, app: &mut App) {
     // 2. Toolbar (Separate Panel below Menu)
     if app.ui_state.show_toolbar {
         egui::TopBottomPanel::top("toolbar_panel")
-            .resizable(true)
+            .resizable(!layout_locked)
             .min_height(if compact_height { 36.0 } else { 44.0 })
             .frame(
                 egui::Frame::default()
@@ -41,7 +55,7 @@ pub fn show(ctx: &egui::Context, app: &mut App) {
     // 3. Left Panel: Sidebar (Collapsible & Resizable)
     if app.ui_state.show_left_sidebar {
         egui::SidePanel::left("left_sidebar_panel")
-            .resizable(true)
+            .resizable(!layout_locked)
             .default_width(sidebar_default)
             .min_width(220.0)
             .max_width((viewport_width * 0.45).max(340.0))
@@ -178,7 +192,7 @@ pub fn show(ctx: &egui::Context, app: &mut App) {
     // 4. Right Panel: Inspector (Docked & Resizable)
     if app.ui_state.show_inspector {
         egui::SidePanel::right("right_panel")
-            .resizable(true)
+            .resizable(!layout_locked)
             .default_width(inspector_default)
             .min_width(260.0)
             .max_width((viewport_width * 0.5).max(420.0))
@@ -216,8 +230,8 @@ pub fn show(ctx: &egui::Context, app: &mut App) {
     // 5. Bottom Panel: Timeline (Resizable)
     if app.ui_state.show_timeline {
         egui::TopBottomPanel::bottom("bottom_panel")
-            .resizable(true)
-            .default_height(if compact_height { 150.0 } else { 220.0 })
+            .resizable(!layout_locked)
+            .default_height(timeline_default)
             .min_height(if compact_height { 80.0 } else { 110.0 })
             .show(ctx, |ui_obj| {
                 ui_obj.heading(app.ui_state.i18n.t("timeline"));

--- a/crates/mapmap/src/ui/dialogs/settings.rs
+++ b/crates/mapmap/src/ui/dialogs/settings.rs
@@ -37,12 +37,14 @@ pub struct SettingsContext<'a> {
 /// Show settings dialog
 pub fn show(ctx: &Context, context: SettingsContext) {
     let mut show_settings = context.ui_state.show_settings;
-    let i18n = &context.ui_state.i18n;
 
     Window::new(
-        RichText::new(format!("⚙ {}", i18n.t("settings").to_uppercase()))
-            .strong()
-            .color(Color32::from_rgb(0, 255, 255)),
+        RichText::new(format!(
+            "⚙ {}",
+            context.ui_state.i18n.t("settings").to_uppercase()
+        ))
+        .strong()
+        .color(Color32::from_rgb(0, 255, 255)),
     )
     .open(&mut show_settings)
     .resizable(true)
@@ -52,7 +54,7 @@ pub fn show(ctx: &Context, context: SettingsContext) {
             ui.heading(RichText::new("General").color(Color32::WHITE));
             ui.add_space(4.0);
             ui.horizontal(|ui| {
-                ui.label(format!("{}:", i18n.t("language")));
+                ui.label(format!("{}:", context.ui_state.i18n.t("language")));
                 let current_lang = context.ui_state.user_config.language.clone();
                 let lang_name = if current_lang == "de" {
                     "Deutsch"
@@ -84,10 +86,10 @@ pub fn show(ctx: &Context, context: SettingsContext) {
             });
             ui.add_space(10.0);
             ui.separator();
-            ui.heading(RichText::new(i18n.t("appearance")).color(Color32::WHITE));
+            ui.heading(RichText::new(context.ui_state.i18n.t("appearance")).color(Color32::WHITE));
             ui.add_space(4.0);
             ui.horizontal(|ui| {
-                ui.label(format!("{}:", i18n.t("theme")));
+                ui.label(format!("{}:", context.ui_state.i18n.t("theme")));
                 let current_theme = context.ui_state.user_config.theme.theme;
                 egui::ComboBox::from_id_salt("theme_selector")
                     .selected_text(format!("{:?}", current_theme))
@@ -186,8 +188,8 @@ pub fn show(ctx: &Context, context: SettingsContext) {
             ui.heading(
                 RichText::new(format!(
                     "{} & {}",
-                    i18n.t("graphics"),
-                    i18n.t("performance")
+                    context.ui_state.i18n.t("graphics"),
+                    context.ui_state.i18n.t("performance")
                 ))
                 .color(Color32::WHITE),
             );
@@ -196,10 +198,10 @@ pub fn show(ctx: &Context, context: SettingsContext) {
                 .num_columns(2)
                 .spacing([20.0, 8.0])
                 .show(ui, |ui| {
-                    ui.label(format!("{}:", i18n.t("hw-accel")));
+                    ui.label(format!("{}:", context.ui_state.i18n.t("hw-accel")));
                     ui.label("Enabled");
                     ui.end_row();
-                    ui.label(format!("{}:", i18n.t("target-fps")));
+                    ui.label(format!("{}:", context.ui_state.i18n.t("target-fps")));
                     let mut fps = context.ui_state.user_config.target_fps.unwrap_or(60.0);
                     if ui
                         .add(egui::Slider::new(&mut fps, 24.0..=144.0).suffix(" FPS"))
@@ -253,15 +255,146 @@ pub fn show(ctx: &Context, context: SettingsContext) {
                 });
             ui.add_space(10.0);
             ui.separator();
-            ui.heading(RichText::new(i18n.t("audio")).color(Color32::WHITE));
+            ui.heading(RichText::new("Layout Profiles").color(Color32::WHITE));
+            ui.add_space(4.0);
+
+            let active_layout_before = context.ui_state.user_config.active_layout_id.clone();
+            let layout_items: Vec<(String, String)> = context
+                .ui_state
+                .user_config
+                .layouts
+                .iter()
+                .map(|l| (l.id.clone(), l.name.clone()))
+                .collect();
+
+            let mut selected_layout_id = active_layout_before.clone();
+            ui.horizontal(|ui| {
+                ui.label("Aktives Layout:");
+                egui::ComboBox::from_id_salt("layout_profile_selector")
+                    .selected_text(
+                        layout_items
+                            .iter()
+                            .find(|(id, _)| id == &selected_layout_id)
+                            .map(|(_, name)| name.clone())
+                            .unwrap_or_else(|| selected_layout_id.clone()),
+                    )
+                    .show_ui(ui, |ui| {
+                        for (id, name) in &layout_items {
+                            if ui
+                                .selectable_label(selected_layout_id == *id, name)
+                                .clicked()
+                            {
+                                selected_layout_id = id.clone();
+                            }
+                        }
+                    });
+
+                if ui.button("Duplizieren").clicked() {
+                    if let Some(active) = context.ui_state.user_config.active_layout().cloned() {
+                        let mut clone = active;
+                        let next = context.ui_state.user_config.layouts.len() + 1;
+                        clone.id = format!("layout-{}", next);
+                        clone.name = format!("{} {}", clone.name, next);
+                        context.ui_state.user_config.add_layout_profile(clone);
+                        let _ = context.ui_state.user_config.save();
+                    }
+                }
+
+                if ui.button("Zurücksetzen").clicked() {
+                    if let Some(layout) = context.ui_state.user_config.active_layout_mut() {
+                        let id = layout.id.clone();
+                        let name = layout.name.clone();
+                        *layout = mapmap_ui::core::config::LayoutProfile::default_profile();
+                        layout.id = id;
+                        layout.name = name;
+                    }
+                    context.ui_state.apply_active_layout();
+                    let _ = context.ui_state.user_config.save();
+                }
+            });
+
+            if selected_layout_id != active_layout_before
+                && context
+                    .ui_state
+                    .user_config
+                    .set_active_layout(&selected_layout_id)
+            {
+                context.ui_state.apply_active_layout();
+                let _ = context.ui_state.user_config.save();
+            }
+
+            ui.add_space(4.0);
+            ui.label("Panel-Sichtbarkeit");
+            let mut changed_visibility = false;
+            changed_visibility |= ui
+                .checkbox(&mut context.ui_state.show_toolbar, "Toolbar")
+                .changed();
+            changed_visibility |= ui
+                .checkbox(&mut context.ui_state.show_left_sidebar, "Left Sidebar")
+                .changed();
+            changed_visibility |= ui
+                .checkbox(&mut context.ui_state.show_inspector, "Inspector")
+                .changed();
+            changed_visibility |= ui
+                .checkbox(&mut context.ui_state.show_timeline, "Timeline")
+                .changed();
+            changed_visibility |= ui
+                .checkbox(&mut context.ui_state.show_media_browser, "Media Browser")
+                .changed();
+            changed_visibility |= ui
+                .checkbox(&mut context.ui_state.show_module_canvas, "Module Canvas")
+                .changed();
+
+            if changed_visibility {
+                context.ui_state.sync_runtime_to_active_layout();
+                let _ = context.ui_state.user_config.save();
+            }
+
+            if let Some(layout) = context.ui_state.user_config.active_layout_mut() {
+                ui.add_space(4.0);
+                ui.label("Panel-Größen");
+                let mut changed_sizes = false;
+                changed_sizes |= ui
+                    .add(
+                        egui::Slider::new(
+                            &mut layout.panel_sizes.left_sidebar_width,
+                            220.0..=640.0,
+                        )
+                        .text("Sidebar Breite"),
+                    )
+                    .changed();
+                changed_sizes |= ui
+                    .add(
+                        egui::Slider::new(&mut layout.panel_sizes.inspector_width, 260.0..=760.0)
+                            .text("Inspector Breite"),
+                    )
+                    .changed();
+                changed_sizes |= ui
+                    .add(
+                        egui::Slider::new(&mut layout.panel_sizes.timeline_height, 100.0..=500.0)
+                            .text("Timeline Höhe"),
+                    )
+                    .changed();
+                changed_sizes |= ui
+                    .checkbox(&mut layout.lock_layout, "Layout sperren")
+                    .changed();
+
+                if changed_sizes {
+                    let _ = context.ui_state.user_config.save();
+                }
+            }
+
+            ui.add_space(10.0);
+            ui.separator();
+            ui.heading(RichText::new(context.ui_state.i18n.t("audio")).color(Color32::WHITE));
             ui.add_space(4.0);
             ui.horizontal(|ui| {
-                ui.label(format!("{}:", i18n.t("label-device")));
+                ui.label(format!("{}:", context.ui_state.i18n.t("label-device")));
                 let current_device = context
                     .ui_state
                     .selected_audio_device
                     .clone()
-                    .unwrap_or_else(|| i18n.t("no-device"));
+                    .unwrap_or_else(|| context.ui_state.i18n.t("no-device"));
                 egui::ComboBox::from_id_salt("audio_device_selector")
                     .selected_text(&current_device)
                     .show_ui(ui, |ui| {
@@ -353,7 +486,7 @@ pub fn show(ctx: &Context, context: SettingsContext) {
             ui.vertical_centered(|ui| {
                 if ui
                     .button(
-                        RichText::new(i18n.t("restart-app"))
+                        RichText::new(context.ui_state.i18n.t("restart-app"))
                             .color(Color32::RED)
                             .strong(),
                     )


### PR DESCRIPTION
### Motivation

- Introduce persistent, user-manageable UI layout profiles so visibility and panel sizing can be saved and restored across sessions.
- Provide runtime/app plumbing to apply and synchronize layout changes between UI state and stored profiles.

### Description

- Adds `LayoutVisibility`, `LayoutPanelSizes`, and `LayoutProfile` structs to `core::config` with defaults and serde support and introduces `layouts: Vec<LayoutProfile>` and `active_layout_id: String` in `UserConfig`.
- Adds helpers `ensure_layout_profiles`, `active_layout`, `active_layout_mut`, `set_active_layout`, and `add_layout_profile`, and ensures `UserConfig::load` repairs missing/empty profile state.
- Applies active layout during `AppUI::default`, exposes `apply_active_layout` and `sync_runtime_to_active_layout` to keep runtime visibility flags and the active profile in sync, and updates UI layout code to use profile `panel_sizes` and `lock_layout` to control resizability.
- Adds settings UI for layout profiles (select, duplicate, reset), panel visibility checkboxes, panel size sliders and a lock option, and persists changes; updates action handling to detect visibility changes and save the active profile.
- Adds default size helpers and wiring for serialization compatibility, and updates existing serialization tests to include layout fields.

### Testing

- Ran the unit tests in `crates/mapmap-ui` including `test_default_config`, `test_serialize_deserialize`, `test_ensure_layout_profiles_repairs_empty_state`, and `test_set_active_layout`, and they all passed under `cargo test`.
- Performed a build of the workspace (`cargo build`) to ensure cross-crate changes compile successfully and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b210fe435c832d9c96a159b75a7951)