### PR TITLE
fix(ci): recover auto-merge after branch update

### DIFF
--- a/.github/workflows/CICD-DevFlow_Job02_AutoMerge.yml
+++ b/.github/workflows/CICD-DevFlow_Job02_AutoMerge.yml
@@ -18,12 +18,15 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   AUTO_MERGE_ENABLED: true
   AUTO_UPDATE_BRANCH_WHEN_BEHIND: true
+  VALIDATION_WORKFLOW_ID: CICD-DevFlow_Job01_Validation.yml
+  DEFAULT_RUST_TOOLCHAIN: ${{ vars.MAPFLOW_DEFAULT_TOOLCHAIN || '1.94.0' }}
 
 concurrency:
   group: auto-merge-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.workflow_run.head_sha || github.run_id }}
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   issues: write
@@ -85,6 +88,70 @@ jobs:
               }
             };
 
+            const VALIDATION_CHECK_NAMES = new Set([
+              'Quality Gate (Format & Lint)',
+              'Security Scan',
+              'Build & Test (Linux)',
+              'Build & Test (Windows)',
+              'Build (macOS Beta)',
+              'Validation Success',
+            ]);
+
+            const waitForHeadShaChange = async (pullNumber, previousHeadSha) => {
+              for (let attempt = 1; attempt <= 20; attempt += 1) {
+                await sleep(3000);
+
+                const refreshedPr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                });
+
+                if (refreshedPr.data.head.sha !== previousHeadSha) {
+                  return refreshedPr.data;
+                }
+              }
+
+              return null;
+            };
+
+            const waitForValidationChecksOnHead = async (headSha) => {
+              for (let attempt = 1; attempt <= 10; attempt += 1) {
+                const checks = await github.rest.checks.listForRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: headSha,
+                  per_page: 100,
+                });
+
+                if (checks.data.check_runs.some((run) => VALIDATION_CHECK_NAMES.has(run.name))) {
+                  return true;
+                }
+
+                await sleep(3000);
+              }
+
+              return false;
+            };
+
+            const dispatchValidationWorkflow = async (branchRef) => {
+              const response = await github.request(
+                'POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: process.env.VALIDATION_WORKFLOW_ID || 'CICD-DevFlow_Job01_Validation.yml',
+                  ref: branchRef,
+                  inputs: {
+                    toolchain: process.env.DEFAULT_RUST_TOOLCHAIN || '1.94.0',
+                  },
+                  return_run_details: true,
+                },
+              );
+
+              return response.data;
+            };
+
             const updateBranchIfBehind = async (pr, phaseLabel) => {
               if (process.env.AUTO_UPDATE_BRANCH_WHEN_BEHIND !== 'true') {
                 await upsertManagedComment(
@@ -100,17 +167,48 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: pr.number,
                 });
-
-                await upsertManagedComment(
-                  pr.number,
-                  `Auto-merge hat waehrend ${phaseLabel} erkannt, dass der PR hinter \`main\` liegt, und ein automatisches Branch-Update angestossen. Die Pflicht-Checks laufen jetzt auf dem neuen Head-SHA erneut an.`,
-                );
               } catch (error) {
                 const message = error?.status === 422
                   ? 'Auto-merge konnte den Branch nicht automatisch aktualisieren. GitHub meldet, dass der PR aktuell nicht per Update-Branch aktualisiert werden kann.'
                   : `Auto-merge konnte den Branch nicht automatisch aktualisieren: ${error.message}`;
 
                 await upsertManagedComment(pr.number, `${message}\n\nBitte aktualisiere den Branch manuell.`);
+                return true;
+              }
+
+              const updatedPr = await waitForHeadShaChange(pr.number, pr.head.sha);
+              if (!updatedPr) {
+                await upsertManagedComment(
+                  pr.number,
+                  'Auto-merge hat ein automatisches Branch-Update angestossen, aber der neue Head-SHA konnte nicht rechtzeitig bestaetigt werden. Bitte pruefe den PR erneut.',
+                );
+                return true;
+              }
+
+              const validationStartedAutomatically = await waitForValidationChecksOnHead(updatedPr.head.sha);
+              if (validationStartedAutomatically) {
+                await upsertManagedComment(
+                  pr.number,
+                  `Auto-merge hat waehrend ${phaseLabel} erkannt, dass der PR hinter \`main\` liegt, ein automatisches Branch-Update angestossen und bestaetigt, dass die Validation-Checks auf dem neuen Head-SHA erneut laufen.`,
+                );
+                return true;
+              }
+
+              try {
+                const dispatchResult = await dispatchValidationWorkflow(updatedPr.head.ref);
+                const detailsSuffix = dispatchResult?.html_url
+                  ? `\n\nValidation-Run: ${dispatchResult.html_url}`
+                  : '';
+
+                await upsertManagedComment(
+                  pr.number,
+                  `Auto-merge hat waehrend ${phaseLabel} erkannt, dass der PR hinter \`main\` liegt und ein automatisches Branch-Update angestossen. Da GitHub auf dem neuen Head-SHA keinen neuen Validation-Lauf gestartet hat, wurde \`CICD-DevFlow: Job01 Validation\` zusaetzlich per workflow_dispatch fuer den aktualisierten Branch gestartet.${detailsSuffix}`,
+                );
+              } catch (error) {
+                await upsertManagedComment(
+                  pr.number,
+                  `Auto-merge hat den Branch aktualisiert, konnte die Validation aber nicht automatisch neu anstossen: ${error.message}\n\nBitte starte \`CICD-DevFlow: Job01 Validation\` manuell fuer den aktualisierten Branch.`,
+                );
               }
 
               return true;

--- a/.github/workflows/CICD-DevFlow_Job02_AutoMerge.yml
+++ b/.github/workflows/CICD-DevFlow_Job02_AutoMerge.yml
@@ -152,6 +152,52 @@ jobs:
               return response.data;
             };
 
+            const recoverValidationAfterBranchUpdate = async (pr) => {
+              const headCommit = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha,
+              });
+
+              const commitMessage = headCommit.data.commit.message || '';
+              const authorLogin = headCommit.data.author?.login || headCommit.data.committer?.login || '';
+              const looksLikeAutomatedBranchUpdate =
+                authorLogin === 'github-actions[bot]' &&
+                commitMessage.startsWith(`Merge branch 'main' into ${pr.head.ref}`);
+
+              if (!looksLikeAutomatedBranchUpdate) {
+                return false;
+              }
+
+              const validationStartedAutomatically = await waitForValidationChecksOnHead(pr.head.sha);
+              if (validationStartedAutomatically) {
+                await upsertManagedComment(
+                  pr.number,
+                  'Auto-merge hat erkannt, dass der aktuelle Head-SHA bereits durch ein automatisches Branch-Update entstanden ist, und bestaetigt, dass die Validation-Checks inzwischen erneut laufen.',
+                );
+                return true;
+              }
+
+              try {
+                const dispatchResult = await dispatchValidationWorkflow(pr.head.ref);
+                const detailsSuffix = dispatchResult?.html_url
+                  ? `\n\nValidation-Run: ${dispatchResult.html_url}`
+                  : '';
+
+                await upsertManagedComment(
+                  pr.number,
+                  `Auto-merge hat erkannt, dass der PR-Branch bereits automatisiert auf \`main\` aktualisiert wurde, aber auf dem neuen Head-SHA kein Validation-Lauf gestartet wurde. Deshalb wurde \`CICD-DevFlow: Job01 Validation\` nachtraeglich per workflow_dispatch gestartet.${detailsSuffix}`,
+                );
+              } catch (error) {
+                await upsertManagedComment(
+                  pr.number,
+                  `Auto-merge hat einen bereits aktualisierten PR-Branch erkannt, konnte die Validation aber nicht nachtraeglich starten: ${error.message}\n\nBitte starte \`CICD-DevFlow: Job01 Validation\` manuell fuer den aktuellen Head-SHA.`,
+                );
+              }
+
+              return true;
+            };
+
             const updateBranchIfBehind = async (pr, phaseLabel) => {
               if (process.env.AUTO_UPDATE_BRANCH_WHEN_BEHIND !== 'true') {
                 await upsertManagedComment(
@@ -448,6 +494,10 @@ jobs:
             }
 
             if (!allRequiredPassed) {
+              if (await recoverValidationAfterBranchUpdate(pr)) {
+                return;
+              }
+
               await upsertManagedComment(
                 prNumber,
                 `Auto-merge wartet noch auf erfolgreiche Pflicht-Checks: ${missingOrFailed.join(', ')}.`,


### PR DESCRIPTION
## Summary
- keep automatic branch updates for behind PRs
- explicitly dispatch validation when GitHub does not restart it on the updated head
- recover if another run already updated the branch before this workflow evaluates the PR

## Verification
- reproduced the broken path with a temporary PR branch updated by github-actions
- verified the old workflow on main leaves the PR head without validation checks after update-branch
- added recovery logic for that state in this PR
